### PR TITLE
Add _byehook macro

### DIFF
--- a/optex/base/basic-macros.opm
+++ b/optex/base/basic-macros.opm
@@ -97,10 +97,14 @@
    if there were unresolved references.
    \_cod ------------------------------
 
-\_def\_byehook{%
+\_def\_warnunifont{%
 \_ifx\_initunifonts\_relax \_relax\_else%
 \_opwarning{You forgot to load a Unicode font}%
 \_fi%
+}
+
+\_def\_byehook{%
+\_warnunifont%
 \_ifnum\_unresolvedrefs>0%
 \_opwarning{Rerun to get references right}%
 \_fi%

--- a/optex/base/basic-macros.opm
+++ b/optex/base/basic-macros.opm
@@ -92,6 +92,20 @@
 
 \_public \loggingall \tracingall ; 
 
+   \_doc ------------------------------
+   Write a warning if the user forgot to load a Unicode Font {\em or} 
+   if there were unresolved references.
+   \_cod ------------------------------
+
+\_def\_byehook{%
+\_ifx\_initunifonts\_relax \_relax\_else%
+\_opwarning{You forgot to load a Unicode font}%
+\_fi%
+\_ifnum\_unresolvedrefs>0%
+\_opwarning{Rerun to get references right}%
+\_fi%
+}
+
 \_endcode % -------------------------------------
 
 

--- a/optex/base/basic-macros.opm
+++ b/optex/base/basic-macros.opm
@@ -93,21 +93,17 @@
 \_public \loggingall \tracingall ; 
 
    \_doc ------------------------------
-   Write a warning if the user forgot to load a Unicode Font {\em or} 
+   Write a warning if the user did not to load a Unicode Font {\em or}
    if there were unresolved references.
    \_cod ------------------------------
 
-\_def\_warnunifont{%
-\_ifx\_initunifonts\_relax \_relax\_else%
-\_opwarning{You forgot to load a Unicode font}%
-\_fi%
-}
-
-\_def\_byehook{%
-\_warnunifont%
-\_ifnum\_unresolvedrefs>0%
-\_opwarning{Rerun to get references right}%
-\_fi%
+\_def\_byehook{
+\_ifx\_initunifonts\_relax \_relax\_else
+\_opwarning{Unicode font was not loaded}
+\_fi
+\_ifnum\_unresolvedrefs>0
+\_opwarning{Rerun to get references right}
+\_fi
 }
 
 \_endcode % -------------------------------------

--- a/optex/base/cite-bib.opm
+++ b/optex/base/cite-bib.opm
@@ -89,6 +89,7 @@
    \_ifcsname _bib:#1#2\_endcsname \_else
       \_addcitelist{#1#2}%
       \_opwarning{The cite [#1#2] unknown. Try to TeX me again}\_openref
+      \_incr\_unresolvedrefs%
       \_addto\_savedcites{?,}\_def\_sortcitesA{}\_lastcitenum=0
       \_ea\_gdef \_csname _bib:#1#2\_endcsname {}%
       \_ea\_skiptorelax \_fi

--- a/optex/base/fnotes.opm
+++ b/optex/base/fnotes.opm
@@ -92,7 +92,8 @@
    \_ifpgfnote \_openref \_fi
    \_wref \_Xfnote{}%
    \_ifpgfnote \_ifcsname _fn:\_the\_gfnotenum \_endcsname \_else
-       \_opwarning{unknown \_noexpand\fnote mark. TeX me again}
+       \_opwarning{unknown \_noexpand\fnote mark. TeX me again}%
+       \_incr\_unresolvedrefs%
    \_fi\_fi
    \_opfootnote\_fnset\_printfnotemarkB
 }

--- a/optex/base/fnotes.opm
+++ b/optex/base/fnotes.opm
@@ -148,7 +148,8 @@
       \_ifcsname _mn:\_the\_mnotenum \_endcsname 
           \_edef\_mnotesfixed{\_cs{_mn:\_the\_mnotenum}}%
       \_else
-          \_opwarning{unknown \_noexpand\mnote side. TeX me again}\_openref
+          \_opwarning{unknown \_noexpand\mnote side. TeX me again}\_openref%
+          \_incr\_unresolvedrefs%
           \_def\_mnotesfixed{\_right}%
    \_fi\_fi
    \_hbox to0pt{\_wref\_Xmnote{}\_everypar={}%

--- a/optex/base/makeindex.opm
+++ b/optex/base/makeindex.opm
@@ -283,7 +283,8 @@
    \_cod -----------------------------
 
 \_def\_makeindex{\_par
-  \_ifx\_iilist\_empty \_opwarning{index data-buffer is empty. TeX me again}
+  \_ifx\_iilist\_empty \_opwarning{index data-buffer is empty. TeX me again}%
+  \_incr\_unresolvedrefs%
   \_else
     \_dosorting \_iilist % sorting \_iilist   
     \_bgroup

--- a/optex/base/maketoc.opm
+++ b/optex/base/maketoc.opm
@@ -99,7 +99,8 @@
    \_cod ----------------------------------
 
 \_def\_maketoc{\_par \_ifx\_toclist\_empty
-      \_opwarning{\_noexpand\maketoc -- data unavailable, TeX me again}\_openref
+      \_opwarning{\_noexpand\maketoc -- data unavailable, TeX me again}\_openref%
+      \_incr\_unresolvedrefs%
    \_else \_begingroup 
       \_tocrefnum=0 \_penalty11333 
       \_the\_regtoc \_toclist 

--- a/optex/base/outlines.opm
+++ b/optex/base/outlines.opm
@@ -5,6 +5,7 @@
 \_def\_outlines#1{\_pdfcatalog{/PageMode/UseOutlines}\_openref
    \_ifx\_toclist\_empty
      \_opwarning{\_noexpand\outlines -- data unavailable. TeX me again}%
+     \_incr\_unresolvedrefs%
    \_else
      \_ifx\_dest\_destactive \_else
         \_opwarning{\_noexpand\outlines doesn't work when \_noexpand\hyperlinks isn't declared}\_fi

--- a/optex/base/plain-macros.opm
+++ b/optex/base/plain-macros.opm
@@ -332,7 +332,7 @@
 \_def \_showhyphens #1{\_setbox0=\_vbox{\_parfillskip=0pt \_hsize=\_maxdimen \_tenrm
   \_pretolerance=-1 \tolerance=-1 \hbadness=0 \showboxdepth=0 \ #1}}
 
-\_def \_bye {\_par \_vfill \_supereject \_end}
+\_def \_bye {\_par \_vfill \_supereject \_byehook \_end}
 \_public \bye ;
 
 \_endcode % -------------------------------------

--- a/optex/base/references.opm
+++ b/optex/base/references.opm
@@ -10,6 +10,13 @@
 \_def\_Xpage#1#2{\_def\_currpage{{#1}{#2}}\_lfnotenum=0 }
 
    \_doc ----------------------------
+   Counter for unresolved references.
+   \_cod ----------------------------
+
+\_newcount\_unresolvedrefs
+\_unresolvedrefs=0
+
+   \_doc ----------------------------
    \`\_Xlabel` `{<label>}{<text>}` saves the <text> to `\_lab:<label>` and saves
    `[pg:<gpageno>]{<pageno>}` to `\_pgref:<label>`.
    \_cod ----------------------------
@@ -53,12 +60,14 @@
 
 \_def\_ref[#1]{\_isdefined{_lab:#1}%
   \_iftrue \_ilink[ref:#1]{\_csname _lab:#1\_endcsname}%
-  \_else ??\_opwarning{label [#1] unknown. Try to TeX me again}\_openref
+  \_else ??\_opwarning{label [#1] unknown. Try to TeX me again}%
+  \_incr\_unresolvedrefs\_openref%
   \_fi
 }
 \_def\_pgref[#1]{\_isdefined{_pgref:#1}%
   \_iftrue \_ea\_ea\_ea\_ilink \_csname _pgref:#1\_endcsname
-  \_else ??\_opwarning{pg-label [#1] unknown. Try to TeX me again}\_openref
+  \_else ??\_opwarning{pg-label [#1] unknown. Try to TeX me again}%
+  \_incr\_unresolvedrefs\_openref%
   \_fi
 }
 \_public \ref \pgref ;

--- a/optex/base/slides.opm
+++ b/optex/base/slides.opm
@@ -140,7 +140,7 @@
    \_sdef{_spg:;}{\_closepage \_global\_slidelayer=1 \_resetpage \_openslide}
    \_sdef{_spg:.}{\_closepage \_end}
    \_sdef{_spg:+}{\_closepage \_incr\_slidelayer \_decr\_pageno \_openslide}
-   \_def\bye     {\_closepage \_end}
+   \_def\bye     {\_closepage \_byehook \_end}
    \_let\_layers=\_layersactive
    \_def\_destbox[##1:##2]{\_isequal{##1}{ref}\_iffalse \_destboxori[##1:##2]\_fi}%
 }


### PR DESCRIPTION
- Before '\bye' print a warning if the user forgot to load a Unicode font.
- Before '\bye' print a warning if there were unresolved references.