### PR TITLE
Tweak optical sizes of 8-bit fonts

### DIFF
--- a/optex/base/fonts-resize.opm
+++ b/optex/base/fonts-resize.opm
@@ -203,7 +203,7 @@
 \_regtfm lmbx 0 ec-lmbx5 5.5 ec-lmbx6 6.5 ec-lmbx7 7.5 ec-lmbx8 8.5 ec-lmbx9 9.5 
                 ec-lmbx10 11.1 ec-lmbx12 *
 \_regtfm lmri 0 ec-lmri7 7.5 ec-lmri8 8.5 ec-lmri9 9.5 ec-lmri10 11.1 ec-lmri12 *
-\_regtfm lmtt 0 ec-lmtt10 11.1 ec-lmtt12 *
+\_regtfm lmtt 0 ec-lmtt8 8.5 ec-lmtt9 9.5 ec-lmtt10 11.1 ec-lmtt12 *
 
 \_setfontsize {at10pt} % default font size
 

--- a/optex/base/math-preload.opm
+++ b/optex/base/math-preload.opm
@@ -94,7 +94,7 @@
 \_regtfm cmbx 0 cmbx5 5.5 cmbx6 6.5 cmbx7 7.5 cmbx8 8.5 cmbx9 9.5 
                 cmbx10 11.1 cmbx12 *
 \_regtfm cmti 0 cmti7 7.5 cmti8 8.5 cmti9 9.5 cmti10 11.1 cmti12 *
-\_regtfm cmtt 0 cmtt10 11.1 cmtt12 *
+\_regtfm cmtt 0 cmtt8 8.5 cmtt9 9.5 cmtt10 11.1 cmtt12 *
 
 %% AMS math fonts, optical sizes:
 
@@ -103,8 +103,8 @@
 
 %% fraktur, rsfs, optical sizes:
 
-\_regtfm eufm 0 eufm5 5.5 eufm6 6.5 eufm7 7.5 eufm8 8.5 eufm9 9.5 eufm10 *
-\_regtfm eufb 0 eufb5 5.5 eufb6 6.5 eufb7 7.5 eufb8 8.5 eufb9 9.5 eufb10 *
+\_regtfm eufm 0 eufm5 6 eufm7 8.5 eufm10 *
+\_regtfm eufb 0 eufb5 6 eufb7 8.5 eufb10 *
 \_regtfm rsfs 0 rsfs5 6 rsfs7 8.5 rsfs10 *
 
 %% bf and bi sansserif math alternatives:


### PR DESCRIPTION
For ec-lmtt and cmtt, add more optical sizes.

In the case of Euler fonts, `euler.map` from amsfonts says:
"The 6, 8 and 9 point sizes of the Euler alphabetic fonts no longer have
independent implementations and exist only as TFM files, which have to
be retained for compatibility with DVI files created with previous
versions of the Euler fonts.  So, we continue supporting them via the
following substitutions.:

eufb6  EUFB7  <eufb7.pfb
eufb8  EUFB7  <eufb7.pfb
eufb9  EUFB10 <eufb10.pfb
..."