### PR TITLE
Fixed typos

### DIFF
--- a/optex/base/hyperlinks.opm
+++ b/optex/base/hyperlinks.opm
@@ -45,7 +45,7 @@
 \_public \ilink \link ;
 
    \_doc ----------------------------
-   \`\ulink``[<url>]{<text>}` creates external link. It prints only te `<text>` by default but
+   \`\ulink``[<url>]{<text>}` creates external link. It prints only the `<text>` by default but
    the \^`\hyperlinks` declaration defines it as \`\_urlactive``[url:<url>]{<text>}`.
    The external link is created by the `\_pdfstartlink...\pdfendlink` primitives.
    The `<url>` is detokenized with `\escapechar=-1` before it is used, so 

--- a/optex/base/parameters.opm
+++ b/optex/base/parameters.opm
@@ -488,7 +488,7 @@
    `\globaldefs=1` prefix. The `\nextpages` is reset to empty after
    processing. Example of usage:
    \begtt
-   \headline={} \nexptages={\headline={\fixedrm \firstmark \hfil}}
+   \headline={} \nexptages={\headline={\rmfixed \firstmark \hfil}}
    \endtt 
    This example sets current page with empty headline, but next pages have 
    non-empty headlines.

--- a/optex/doc/optex-userdoc.tex
+++ b/optex/doc/optex-userdoc.tex
@@ -1734,7 +1734,7 @@ the last page in next \TeX/ runs.
 There is an example for footlines in the format \"current page / last page": 
 
 \begtt
-\footline={\hss \fixedrm \folio/\lastpage \hss}
+\footline={\hss \rmfixed \folio/\lastpage \hss}
 \endtt
 
 \new


### PR DESCRIPTION
\fixedrm is used only twice. It is probably just a typo and it should be \rmfixed.