### PR TITLE
Add sanity check to namespace export macros.

### DIFF
--- a/optex/base/math-macros.opm
+++ b/optex/base/math-macros.opm
@@ -218,7 +218,7 @@
 \_mathchardef\smallint="1273
 
 \_mathchardef\triangleleft="212F   \_private \triangleleft;
-\_mathchardef\triangleright="212E  \_private \trianglerigt;
+\_mathchardef\triangleright="212E  \_private \triangleright;
 \_mathchardef\bigtriangleup="2234
 \_mathchardef\bigtriangledown="2235
 \_mathchardef\wedge="225E \let\land=\wedge

--- a/optex/base/more-macros.opm
+++ b/optex/base/more-macros.opm
@@ -75,7 +75,7 @@
    \_cod -----------------------------
 
 \_def\_normalcatcodes {\_catcodetable\_optexcatcodes \_savecatcodetable0 \_catcodetable0 }
-\_public \normalcatodes ; 
+\_public \normalcatcodes ;
 
    \_doc -----------------------------
    The \`\load` `[<filename-list>]` loads files specfied in

--- a/optex/base/prefixed.opm
+++ b/optex/base/prefixed.opm
@@ -37,10 +37,16 @@
 
 \_def \_pkglabel{}
 \_def \_public {\_xargs \_publicA}
-\_def \_publicA #1{\_ea\_let \_ea#1\_csname  _\_csstring #1\_endcsname}
+\_def \_publicA #1{%
+    \_unless\_ifcsname _\_csstring #1\_endcsname%
+    \_errmessage{Macro '\_bslash _\_csstring #1' was not defined.}\fi%
+    \_ea\_let \_ea#1\_csname  _\_csstring #1\_endcsname}
 
 \_def \_private {\_xargs \_privateA}
-\_def \_privateA #1{\_ea\_let \_csname  _\_csstring #1\_endcsname =#1}
+\_def \_privateA #1{%
+    \_unless\_ifcsname \_csstring #1\_endcsname%
+    \_errmessage{Macro '\_bslash \_csstring #1' was not defined.}\fi%
+    \_ea\_let \_csname  _\_csstring #1\_endcsname =#1}
 
 \_public \public \private \xargs \ea ;
 
@@ -101,12 +107,17 @@
 
 \_def \_nspublic {\_xargs \_nspublicA}
 \_def \_nspublicA #1{%
-   \_unless\_ifx #1\_undefined
-      \_opwarning{\_ea\_ignoreit\_pkglabel\_space redefines the meaning of \_string#1}\_fi
+   \_unless\_ifcsname \_pkglabel _\_csstring #1\_endcsname%
+   \_errmessage{Macro '\_bslash\_pkglabel _\_csstring #1' was not defined.}\fi%
+   \_unless\_ifx #1\_undefined%
+      \_opwarning{\_ea\_ignoreit\_pkglabel\_space redefines the meaning of \_string#1}\_fi%
    \_ea\_let \_ea#1\_csname \_pkglabel _\_csstring #1\_endcsname}
 
 \_def \_nsprivate {\_xargs \_nsprivateA}
-\_def \_nsprivateA #1{\_ea\_let \_csname \_pkglabel _\_csstring #1\_endcsname =#1}
+\_def \_nsprivateA #1{%
+   \_unless\_ifcsname \_csstring #1\_endcsname%
+   \_errmessage{Macro '\_bslash\_csstring #1' was not defined.}\fi%
+   \_ea\_let \_csname \_pkglabel _\_csstring #1\_endcsname =#1}
 
 
 \_endcode %----------------------------------------------------

--- a/optex/base/unimath-codes.opm
+++ b/optex/base/unimath-codes.opm
@@ -417,7 +417,7 @@
    \_cod -----------------------------
 
 \_private
-   \ldotp \cdotp \bullet \triangleleft \trianglerigt \mapstochar \rightarrow
+   \ldotp \cdotp \bullet \triangleleft \triangleright \mapstochar \rightarrow
    \prime \lhook \rightarrow \leftarrow \rhook \triangleright \triangleleft
    \rbrace \lbrace \Relbar \Rightarrow \relbar \rightarrow \Leftarrow \mapstochar
    \longrightarrow \Longleftrightarrow \unicodevdots \unicodeddots \unicodeadots ;


### PR DESCRIPTION
`\public \foo` would make `\let\foo=\relax` in cases were no
corresponding `\_foo` was defined.
This would hide typing errors.

* Change `\_public \foo ;` so that we get an error message if there is
no `\_foo`.
Users that want the old semantic can explicitly write `\let\foo=\relax`
* Change `\_nspublic \foo ;` so that we get an error message if there is
no `\.foo`.
* Change `\_private \foo ;` and `\_nsprivate \foo ;` so that we get an
error message if there is no `\foo`.