### PR TITLE
Provide `\secant` for completness.

### DIFF
--- a/optex/base/math-macros.opm
+++ b/optex/base/math-macros.opm
@@ -321,6 +321,7 @@
 \_protected\_def\cot {\_mathop{\_rm cot}\_nolimits}
 \_protected\_def\coth {\_mathop{\_rm coth}\_nolimits}
 %\_protected\_def\sec {\_mathop{\_rm sec}\_nolimits} % \sec is section
+\_protected\_def\secant {\_mathop{\_rm sec}\_nolimits}
 \_protected\_def\csc {\_mathop{\_rm csc}\_nolimits}
 \_protected\_def\max {\_mathop{\_rm max}}
 \_protected\_def\min {\_mathop{\_rm min}}

--- a/optex/doc/optex-userdoc.tex
+++ b/optex/doc/optex-userdoc.tex
@@ -1994,7 +1994,7 @@ are not defined in \OpTeX/ because they are obsolete. But you can use the
 if you really need such feature.
 
 The `\sec` macro is reserved for sections but original Plain \TeX/ declares this
-control sequence for math secans.
+control sequence for math secant\fnote{Use \code{$\\secant(x)$} to get $\secant(x)$.}.
 
 \enddocument
 


### PR DESCRIPTION
For those users that strongly dislike 1/cos(x) :smile: 