### PR TITLE
Manage graphics states

### DIFF
--- a/optex/base/graphics.opm
+++ b/optex/base/graphics.opm
@@ -319,6 +319,39 @@
 \_public \inoval \incircle \ratio \lwidth \fcolor \lcolor \shadow \overlapmargins ;
 
    \_doc -----------------------------
+   Just before defining shadows, which require special graphics states, we
+   define means for managing these graphics states. This is important, because
+   otherwise our use of `\pdfpageresources` register might clash with other
+   packages (TikZ) or even with our other usage (slides).
+
+   The macro \`\addextgstate``<PDF name> <PDF dictionary>` shall be used for
+   adding more graphics states. It must be used {\em after} `\dump`. First use
+   of it detects PGF/TikZ and either uses its mechanism or defines our own. Our
+   mechanism is very similar though -- use single `/ExtGState` dictionary for all
+   pages (`\pdfpageresources` just points to it).
+   \_cod -----------------------------
+
+\_def\_initpageresources{%
+   \_glet\_initpageresources=\_relax
+   \_ifcsname pgf@sys@addpdfresource@extgs@plain\_endcsname
+      % TikZ loaded
+      \_global\_slet{_addextgstate}{pgf@sys@addpdfresource@extgs@plain}%
+   \_else
+      % TikZ not loaded
+      \_pdfobj reserveobjnum% not to be used in iniTeX
+      \_xdef\_extgstatesobj{\_the\_pdflastobj}%
+      \_expanded{\_global\_pdfpageresources={/ExtGState \_extgstatesobj\_space 0 R}}%
+      \_global\_addto\_byehook{\_immediate\_pdfobj useobjnum\_extgstatesobj {<<\_extgstates>>}}%
+      \_gdef\_extgstates{}%
+      \_gdef\_addextgstate##1{\_xdef\_extgstates{\_extgstates\_space##1}}%
+   \_fi
+}
+% first initialize page resources, then execute new meaning of itself
+\_def\_addextgstate#1{\_initpageresources \_addextgstate{#1}}
+
+\_public \addextgstate ;
+
+   \_doc -----------------------------
    A shadow effect is implemented here. The shadow is equal to the
    silhouette of the given path in a gray-transparent color shifted by
    \`\_shadowmoveto` vector and with blurred boundary.
@@ -333,27 +366,11 @@
 \_def\_shadowmoveto{1.8 -2.5}  % vector defines shifting layer (in bp)
 \_def\_shadowb{1}              % 2*shadowb = blurring area thickness
 
-   \_doc -----------------------------
-   The `\_pdfpageresources` primitive is used to define transparency.
-   It does not work when used in a box. So, we use it at the beginning of
-   the output routine. The modification of the output routine is done
-   using \`\_insertshadowresources` only once when the shadow effect is used first.
-   \_cod -----------------------------
-
 \_def\_insertshadowresources{%
-   \_global\_addto\_begoutput{\_setshadowresources}%
-   \_xdef\_setshadowresources{%
-      \_pdfpageresources{/ExtGState
-      <<
-      /op1  <</Type /ExtGState /ca \_shadowdarknessA>>
-      /op2  <</Type /ExtGState /ca \_shadowdarknessB>>
-      \_morepgresources
-      >>
-      }%
-   }%
-   \_global\_let\_insertshadowresources=\_relax
+   \_addextgstate{/op1 <</ca \_shadowdarknessA>>}%
+   \_addextgstate{/op2 <</ca \_shadowdarknessB>>}%
+   \_glet\_insertshadowresources=\_relax
 }
-\_def\_morepgresources{}
 
    \_doc -----------------------------
    The \`\_doshadow``{<curve>}` does the shadow effect.

--- a/optex/base/slides.opm
+++ b/optex/base/slides.opm
@@ -53,19 +53,20 @@
    \_doc -----------------------------
    The \`\pshow``<num>` prints the text in invisible
    (transparent) font when \^`\layernum`\code{<}`<num>`.
-   The transparency is set by `\pdfpageresoyrces` primitive.
+   For transparency we need to define special graphics states.
    \_cod -----------------------------
 
-\pdfpageresources{/ExtGState << /Invisible << /Type /ExtGState /ca 0 /CA 0 >>
-                                /Visible   << /Type /ExtGState /ca 1 /CA 1 >> >>}
-\addto\_morepgresources{/Invisible << /Type /ExtGState /ca 0 /CA 0 >>
-                        /Visible   << /Type /ExtGState /ca 1 /CA 1 >>}
-\def\Invisible {\_pdfliteral{/Invisible gs}}
-\def\Visible   {\_pdfliteral{/Visible gs}}
-\def\Transparent {\Invisible \_aftergroup \Visible}
+\_addextgstate{/Invisible <</ca 0 /CA 0>>}
+\_addextgstate  {/Visible <</ca 1 /CA 1>>}
+
+\_def\_Invisible   {\_pdfliteral{/Invisible gs}}
+\_def\_Visible     {\_pdfliteral{/Visible gs}}
+\_def\_Transparent {\_Invisible \_aftergroup \_Visible}
+
+\_public \Invisible \Visible \Transparent ;
 
 \_def\_use#1#2{\_ifnum\_layernum#1\_relax#2\_fi}
-\_def\_pshow#1{\_use{=#1}\Red \_use{<#1}\Transparent \_ignorespaces}
+\_def\_pshow#1{\_use{=#1}\Red \_use{<#1}\_Transparent \_ignorespaces}
 
    \_doc -----------------------------
    The main level list of items is activated here. The `\_item:X` and


### PR DESCRIPTION
PDF page resources (like ExtGStates) in the pdfTeX model are settable only using `\pdfpageresources` primtive token register. While that is enough if the register has a single user, it requires a more thorough mechanism for anything more substantial.

I think in OpTeX we reached that point. Shadows and slide layers already used the register, now with the (coming) addition of transparency OpTeX trick and already existing clash with TikZ we have to do something about it.

The implemented solution either hooks into PGF/TikZ's way of managing PDF page resources or creates our own (very similar) mechanism. The principle is to set `\pdfpageresources` to point to pretty much a single global dictionary of ExtGStates (or other resources) that applies to all pages.

The global idea is of course prone to naming clashes. Another catch is that, for example only one value of shadow transparency can be used per document. But that was the case previously as well.