### PR TITLE
Unicode math improvements

### DIFF
--- a/optex/base/math-macros.opm
+++ b/optex/base/math-macros.opm
@@ -1059,8 +1059,8 @@
 \_def\_mathbox#1{{\_mathstyles{\_hbox{%
    \_ifnum\_stylenum<2 \_everymath{\_currstyle}%
    \_else
-      \_ifnum\_stylenum=2 \_def\_textmff{+ssty=0;}\_fi
-      \_ifnum\_stylenum=3 \_def\_textmff{+ssty=1;}\_def\_scriptmff{+ssty=1;}\_fi
+      \_ifnum\_stylenum=2 \_def\_textmff{ssty=1;}\_fi
+      \_ifnum\_stylenum=3 \_def\_textmff{ssty=2;}\_def\_scriptmff{ssty=2;}\_fi
       \_typoscale[\_dobystyle{}{}{700}{500}/]\_fi #1}}}%
 }
 \_public \mathbox ;

--- a/optex/base/math-unicode.opm
+++ b/optex/base/math-unicode.opm
@@ -113,8 +113,8 @@
    loads the given Unicode-math fonts in three sizes given by the
    \^`\setmathsizes` macro and sets it as the math family `<number>`.
    The `<font features>` are added to the default
-   \`\_mfontfeatures` and to the size-dependent features `+ssty=0`
-   if script size is asked or `+ssty=1` if scriptscriptsize is asked.
+   \`\_mfontfeatures` and to the size-dependent features `ssty=1`
+   if script size is asked or `ssty=2` if scriptscriptsize is asked.
    All information needed by \TeX/ is collected in single Unicode-math font.\nl
    The \^`\_corrmsize` `<factor><space>` can be used just before
    `\_loadumathfamily`, see section~\ref[math-preload] for more information.\nl
@@ -136,7 +136,7 @@
   \_scriptscriptfont#1=\_mF
   \_optsize=\_optsizesave \_ptmunit=\_ptunit
 }
-\_def\_textmff{} \_def\_scriptmff{+ssty=0;} \_def\_sscriptmff{+ssty=1;}
+\_def\_textmff{ssty=0;} \_def\_scriptmff{ssty=1;} \_def\_sscriptmff{ssty=2;}
 
    \_doc -----------------------------
    Unicode math font includes all typical math alphabets together, user needs not to

--- a/optex/base/math-unicode.opm
+++ b/optex/base/math-unicode.opm
@@ -87,7 +87,6 @@
 \_def\_setunimathdimens{% PlainTeX sets these dimens for 10pt size only:
   \_delimitershortfall=0.5\_fontdimen6\_textfont1
   \_nulldelimiterspace=0.12\_fontdimen6\_textfont1
-  \_scriptspace=0.05\_fontdimen6\_textfont1
   \_setbox0=\_hbox{\_everymath{}$\_fam1\_displaystyle{0\_atop0}$}%
   \_Umathfractiondelsize\_displaystyle = \_dimexpr(\_ht0-\_Umathaxis\_displaystyle)*2\_relax
   \_setbox0=\_box\_voidbox

--- a/optex/base/math-unicode.opm
+++ b/optex/base/math-unicode.opm
@@ -85,9 +85,9 @@
     \_setunimathdimens
 }%
 \_def\_setunimathdimens{% PlainTeX sets these dimens for 10pt size only:
-  \_delimitershortfall=0.5\_fontdimen6\_textfont3
-  \_nulldelimiterspace=0.12\_fontdimen6\_textfont3
-  \_scriptspace=0.05\_fontdimen6\_textfont3
+  \_delimitershortfall=0.5\_fontdimen6\_textfont1
+  \_nulldelimiterspace=0.12\_fontdimen6\_textfont1
+  \_scriptspace=0.05\_fontdimen6\_textfont1
   \_setbox0=\_hbox{\_everymath{}$\_fam1\_displaystyle{0\_atop0}$}%
   \_Umathfractiondelsize\_displaystyle = \_dimexpr(\_ht0-\_Umathaxis\_displaystyle)*2\_relax
   \_setbox0=\_box\_voidbox
@@ -116,10 +116,7 @@
    The `<font features>` are added to the default
    \`\_mfontfeatures` and to the size-dependent features `+ssty=0`
    if script size is asked or `+ssty=1` if scriptscriptsize is asked.
-   If the math family 1 is loaded then the family 2 and 3 are set by the same
-   font because \TeX/ needs to read dimension information about generating
-   math formulae from these three math families. All information needed by
-   \TeX/ is collected in single Unicode-math font.\nl
+   All information needed by \TeX/ is collected in single Unicode-math font.\nl
    The \^`\_corrmsize` `<factor><space>` can be used just before
    `\_loadumathfamily`, see section~\ref[math-preload] for more information.\nl
    The \`\_textmff`, \`\_scriptmff` and \`\_sscriptmff` are additional font
@@ -133,11 +130,11 @@
 \_def\_loadumathfamily #1 #2#3 {%
   \_edef\_optsizesave{\_the\_optsize}%
   \_optsize=\_sizemtext  \_font\_mF=\_umathname{#2}{\_textmff #3} at\_optsize
-  \_textfont#1=\_mF \_ifnum#1=1 \_textfont2=\_mF \_textfont3=\_mF \_fi
+  \_textfont#1=\_mF
   \_optsize=\_sizemscript \_font\_mF=\_umathname{#2}{\_scriptmff #3} at\_optsize
-  \_scriptfont#1=\_mF \_ifnum#1=1 \_scriptfont2=\_mF \_scriptfont3=\_mF \_fi
+  \_scriptfont#1=\_mF
   \_optsize=\_sizemsscript \_font\_mF=\_umathname{#2}{\_sscriptmff #3} at\_optsize
-  \_scriptscriptfont#1=\_mF \_ifnum#1=1 \_scriptscriptfont2=\_mF \_scriptscriptfont3=\_mF \_fi
+  \_scriptscriptfont#1=\_mF
   \_optsize=\_optsizesave \_ptmunit=\_ptunit
 }
 \_def\_textmff{} \_def\_scriptmff{+ssty=0;} \_def\_sscriptmff{+ssty=1;}

--- a/optex/doc/optex-math.tex
+++ b/optex/doc/optex-math.tex
@@ -1576,8 +1576,7 @@ We can re-define the `\_normalmath` macro by:
 \begtt \typosize[10/12]
 \addto\_normalmath {\_loadmathfamily 5 bbold }
 
-\_regtfm bbold 0 bbold5 5.5 bbold6 6.5 bbold7 7.5 bbold8 8.5 bbold9
-               9.5 bbold10 11.1 bbold12 15 bbold17 * % using all bbold*.tfm
+\_regtfm bbold 0 bbold5 6 bbold7 8.5 bbold10 * % using all bbold*.pfb
 \_normalmath  % reload the math fonts collection
 \endtt
 %
@@ -1585,8 +1584,7 @@ The string \"`bbold`" is declared by `\_regtfm` as a collection of all
 `bbold*.tfm` fonts, the optical sizes are supported.
 
 \addto\_normalmath {\_loadmathfamily 5 bbold }
-\_regtfm bbold 0 bbold5 5.5 bbold6 6.5 bbold7 7.5 bbold8 8.5 bbold9
-               9.5 bbold10 11.1 bbold12 15 bbold17 * % using all bbold*.tfm
+\_regtfm bbold 0 bbold5 6 bbold7 8.5 bbold10 * % using all bbold*.pfb
 \_normalmath
 \Umathchardef \bbplus 2 5 "2B
 \Umathchardef \bble   3 5 "3C


### PR DESCRIPTION
- [x] Don't set math families 2 and 3 for Unicode math

Setting math families 2 and 3 doesn't do anything special for "new math
fonts"

See mlist.c:fixup_math_parameters in LuaTeX source:

https://github.com/TeX-Live/luatex/blob/eee644d052c295920d378ef579a96fcca497af9a/source/texk/web2c/luatexdir/tex/mlist.c#L478

- [ ] Use math family 0 for Unicode math

This allows shorter notation (i.e. 0 is implicit) when using `\Umathchardef`, etc.

This would have also prevented the former bug in `\_setunimathdimens` which is executed before the `\mathcode` for numbers are set:
```diff
  \_delimitershortfall=0.5\_fontdimen6\_textfont3
  \_nulldelimiterspace=0.12\_fontdimen6\_textfont3
  \_scriptspace=0.05\_fontdimen6\_textfont3
-  {\_everymath{}\_global\_setbox0=\_hbox{$\_displaystyle{0\_atop0}$}}% correction for \choose
+  {\_everymath{}\_global\_setbox0=\_hbox{$\_fam1\_displaystyle{0\_atop0}$}}% correction for \choose
  \_Umathfractiondelsize\_displaystyle = \_dimexpr(\_ht0-\_Umathaxis\_displaystyle)*2\_relax

}
```

 - [ ] Possibly more, like:
   - Using the Unicode math mechanism even for old style TeX fonts. This allows having a single code path and should allow https://tex.stackexchange.com/questions/576840/font-extensions-and-conversion.
   - More that comes to my mind?

@olsak What is your plan on next release? I thought that with the amount of breaking changes in this release, we might be able to squeeze in more, so that there aren't several subsequent releases that break things. Possibly labeling the release 2.00, so that it is apparent that there are breaking changes?

Something else I also wanted to try are `\_pagedest` and `\pgref`, and in the spirit of Unicode math only, fonts loaded with `\initunifonts` only (no preloaded fonts).
