### PR TITLE
Fix for new lipsum version

### DIFF
--- a/optex/base/others.opm
+++ b/optex/base/others.opm
@@ -92,6 +92,7 @@
 \_def\_lipsumload{{%
    \_setbox0=\_vbox{\_tmpnum=0 % vertical mode during \input lipsum.ltd.tex
       \_def\ProvidesFile##1[##2]{}%
+      \_def\SetLipsumLanguage##1{}%
       \_def\NewLipsumPar{\_incr\_tmpnum \_sxdef{_lip:\_the\_tmpnum}}%
       \_opinput {lipsum.ltd.tex}%
       \_global\_let\_lipsumload=\_empty


### PR DESCRIPTION
New lipsum version starts the file with `\SetLipsumLanguage{latin}`.