### PR TITLE
Improve/fix `hyperlinks.opm`

### DIFF
--- a/optex/base/hyperlinks.opm
+++ b/optex/base/hyperlinks.opm
@@ -27,19 +27,19 @@
    \_doc ----------------------------
    Each hyperlink is created internally by \`\_xlink``{<type>}{<spec>}{<color>}{<text>}`.
    This macro expands to `\_quitvmode{<text>}` by default, i.e.\ no active
-   hyperlink is created, only <text> is printed in horizontal mode.
-   If \^`\hyperlinks` is used, then `\_xlink` gets meaning of
-   \`\_xlinkactive` and hyperlinks are created using `\pdfstartlink`,
+   hyperlink is created, only <text> is printed in horizontal mode (and in a group).
+   If \^`\hyperlinks` is used, then `\_xlink` gets the meaning of
+   \`\_xlinkactive` and hyperlinks are created by the `\pdfstartlink`/%
    `\pdfendlink` primitives. The <text> has given <color> only when
-   hyperlink is created. But if `\_<type>linkcolor` is defined, it has
-   precedence.
+   hyperlink is created. If `\_<type>linkcolor` is defined, it has
+   precedence over <color>.
    \nl
    The \`\_linkdimens` macro declares the dimensions of link area.
    \nl
    A specific action can be defined for each link <type> by the macro
    `\_<type>action{<spec>}`. \OpTeX/ defines only \`\_urlaction``{<url>}`.
    The default link action (when `\_<type>action` is not defined) is
-   `goto mame{<type>:<spec>}` (creates an internal link). It is declared in the
+   `goto name{<type>:<spec>}` (an internal link). It is declared in the
    \`\_linkactions``{<type>}{<spec>}` macro.
    \nl
    The `\_pdfstartlink` primitive uses `attr{\_pdfborder{<type>}}`. The

--- a/optex/base/hyperlinks.opm
+++ b/optex/base/hyperlinks.opm
@@ -91,14 +91,15 @@
 \_public \ilink \ulink \link ;
 
    \_doc ----------------------------
-   \`\hyperlinks``{<ilink_color>}{<ulink_color>}` activates `\dest`, `\xlink`,
-   in order they create links.
+   \`\hyperlinks``<ilink color><ulink color>` activates `\dest`, `\xlink`,
+   so that they create links. Not setting colors (`\hyperlinks{}{}`) is also
+   supported.
    \_cod ----------------------------
 
 \_def\_hyperlinks#1#2{%
    \_let\_dest=\_destactive \_let\_xlink=\_xlinkactive
-   \_let\_ilinkcolor=#1%
-   \_let\_elinkcolor=#2%
+   \_let\_ilinkcolor=#1\_empty
+   \_let\_elinkcolor=#2\_empty
    \_public \dest \xlink ;%
 }
 \_public \hyperlinks ;


### PR DESCRIPTION
I am in the process of updating the [pdfextra](https://github.com/vlasakm/pdfextra) package to OpTeX v1.04 and I noticed a few things about hyperlinks, that are not critical, but should probably be fixed in the next release:

- [x] documentation typos (and other small deficiencies)
- [x] `\hyperlinks{}{}` doesn't work now, but maybe should? (At least the documentation for `\_printrefnum` should be updated if not.)
- [ ] `\_linkdimens`, which by default tries to achieve "lining links", but are defined in terms of `em` and not in terms of `\baselineskip`.


Two and three are debatable. What do you think @olsak?

Illustration of `\_linkdimens`:

![2021-08-27-140358](https://user-images.githubusercontent.com/9497885/131125077-dd795fac-5936-4635-b9ce-96d6a0b232cc.png)

```
\fontfam[lm]
\typosize[8/12]
\hyperlinks \Blue \Blue
\def \_urlborder {1 0 0}
\lipsum[0]

\def\test{%
    \xlink{url}{https://www.lipsum.com/}{\Magenta}{\_lipsumtext[1]}
}

\test

\bigskip

\def\_linkdimens{height.75\_baselineskip depth.25\_baselineskip}
\test

\bye
```

The `pdfextra` logic for lining links uses `\_baselineskip`, but only for `\hlink` (package namespace). I am thinking about unconditionally replacing `\xlink` with  `\hlink` when `pdfextra` is loaded, so unifying everything that makes sense will prevent surprises. (The link coloring and borders will be the same in the next release, unfortunately the PDF actions logic cannot be shared.)