### PR TITLE
Add basic Lua syntax highlighting

### DIFF
--- a/optex/base/hisyntax-lua.opm
+++ b/optex/base/hisyntax-lua.opm
@@ -1,0 +1,86 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_codedecl \_hisyntaxlua {Syntax highlighting for Lua sources <2021-06-29>}
+
+\_newtoks \_hisyntaxlua  \_newtoks \_hicolorslua
+
+\_global\_hicolorslua={%     colors for the Lua language
+   \_hicolor K \Red      % Keywords
+   \_hicolor S \Magenta  % Strings
+   \_hicolor C \Green    % Comments
+   \_hicolor N \Cyan     % Numbers
+   \_hicolor P \Blue     % Preprocessor
+   \_hicolor O \Blue     % Other tokens
+}
+\_global\_hisyntaxlua={%
+   \_the\_hicolorslua
+   \_let\c=\_relax \_let\e=\_relax \_let\o=\_relax
+   \_replfromto {--[}{--]}   {\x C{--[#1--]}}%  multi line comment --[...--]
+   \_replfromto {--}{^^J}    {\z C{--#1}^^J}%   single line comment --...
+   \_replthis   {\_string\"} {{\_string\"}}%   \" protected inside strings
+   \_replthis   {\_string\'} {{\_string\'}}%   \' protected inside strings
+   \_replfromto {"}{"}       {\x S{"#1"}}%     "..."
+   \_replfromto {'}{'}       {\x S{'#1'}}%     "..."
+   % missing: [[, [=[, [==[ strings, " ' in string of other kind
+   \_edef\_tmpa {{<<}{>>}{//}{==}{\_string~=}{<=}{>=}{::}{...}{..}%
+      +-*/\_pcent^\_csstring\#\_string&\_string~|%
+      <>=()]\_string{\_string}[];:,.}% other tokens
+   \_ea \_foreach \_tmpa
+      \_do {\_replthis{#1}{\n\o{#1}\n}}%
+   \_foreach                                                              % keywords
+      {and}{break}{do}{else}{elseif}{end}{false}{for}{function}{goto}%
+      {if}{in}{local}{nil}{not}{or}{repeat}{return}{then}{true}{until}{while}%
+      \_do {\_replthis{\n#1\n}{\z K{#1}}}%
+   \_replthis{.}{\n.\n}                                                   % numbers
+   \_foreach 0123456789
+      \_do {\_replfromto{\n#1}{\n}{\c#1##1\e}}%
+   \_replthis{\e.\c}{.}%
+   \_replthis{\e.\n}{.\e}%
+   \_replthis{\n.\c}{\c.}%
+   \_replthis{e\e\o+\c}{e+}\_replthis{e\e\o-\c}{e-}%
+   \_replthis{E\e\o+\c}{E+}\_replthis{E\e\o-\c}{E-}%
+   \_def\o#1{\z O{#1}}%
+   \_def\c#1\e{\z N{#1}}%
+}
+
+\_endcode %------------------------------------------------
+
+The list of keywords and special symbols comes from the Lua 5.3 Reference
+Manual\fnote{\url{https://www.lua.org/manual/5.3/manual.html\#3}}, otherwise
+this is mostly a port of `hisyntax-c.opm`.
+
+
+\begtt \hisyntax{lua}
+and       break     do        else      elseif    end
+false     for       function  goto      if        in
+local     nil       not       or        repeat    return
+then      true      until     while
+
+     +     -     *     /     %     ^     #
+     &     ~     |     <<    >>    //
+     ==    ~=    <=    >=    <     >     =
+     (     )     {     }     [     ]     ::
+     ;     :     ,     .     ..    ...
+
+a = 'alo\n123"'
+a = "alo\n123\""
+a = '\97lo\10\04923"'
+a = [[alo
+123"]]
+a = [==[
+alo
+123"]==]
+
+3   345   0xff   0xBEBADA
+
+3.0     3.1416     314.16e-2     0.31416E1     34e1
+0x0.1E  0xA23p-4   0X1.921FB54442D18P+1
+
+1+1 2+a
+
+
+--[ multi line
+comment
+--]
+print(1+1)
+\endtt

--- a/optex/doc/optex-techdoc.tex
+++ b/optex/doc/optex-techdoc.tex
@@ -273,12 +273,6 @@ The allocations are declared in subsection~\ref[lua-alloc], calbacks are
 implemented in subsection~\ref[callbacks] and handling with colors can be
 found in the subsection~\ref[lua-colors].
 
-\newtoks \_hisyntaxlua
-\_hisyntaxlua={%
-   \_hicolor C \Green
-   \_replfromto {--}{^^J}   {\z C{--#1}^^J}%
-}
-
 {\everytt={\typosize[8/10]\_let\_printverbline=\_printcodeline \medskip}
   \commentchars-- \def\docfile{optex.lua} \ttline=-1
   \_def\_printcomments{\_medskip


### PR DESCRIPTION
Doesn't properly support strings and numbers in scientific notation, but is good enough for `optex.lua`.