### PR TITLE
Make luaotfload transparency work with its hooks

### DIFF
--- a/optex/base/fonts-resize.opm
+++ b/optex/base/fonts-resize.opm
@@ -16,7 +16,7 @@
    \_directlua{%
       require('luaotfload-main')
       luaotfload.main()
-      optex_hook_into_luaotfload()
+      optex.hook_into_luaotfload()
    }%
    \_glet \_fmodtt=\_unifmodtt  % use \_ttunifont for \tt
    \_glet \_initunifonts=\_relax % we need not to do this work twice

--- a/optex/base/ref-file.opm
+++ b/optex/base/ref-file.opm
@@ -29,7 +29,7 @@
    printed. Try running `optex op-demo` twice to see the effect.
    \_cod --------------------------
 
-\_def\_mdfive#1{\_directlua{mdfive("#1")}}
+\_def\_mdfive#1{\_directlua{optex.mdfive("#1")}}
 \_def\_prevrefhash{}
 
    \_doc --------------------------


### PR DESCRIPTION
Since we added new PDF resource management, transparent font settings through luaotfload were broken.

It was now possible to fix this thanks to new hooks in luaotfload. See https://github.com/latex3/luaotfload/pull/212.

I tested with https://github.com/vlasakm/optex-minim/blob/master/examples/optex-minim-pgf-test.tex, since that file mixes a lot of things (luaotfload transparency, optex transparency, minim metapost resources, pgf resources, optex macro resources, ...), but didn't do a lot of thorough testing.