### PR TITLE
Update the keyword list in hisyntax-c.opm

### DIFF
--- a/optex/base/hisyntax-c.opm
+++ b/optex/base/hisyntax-c.opm
@@ -25,10 +25,15 @@
    \_ea \_foreach \_tmpa
       \_do {\_replthis{#1}{\n\o#1\n}}
    \_foreach                                                              % keywords
-      {auto}{break}{case}{char}{continue}{default}{do}{double}%
-      {else}{entry}{enum}{extern}{float}{for}{goto}{if}{int}{long}{register}%
-      {return}{short}{sizeof}{static}{struct}{switch}{typedef}{union}%
-      {unsigned}{void}{while}
+      {alignas}{alignof}{auto}{bool}{break}{case}{char}{const}%
+      {constexpr}{continue}{default}{do}{double}{else}{enum}{extern}%
+      {false}{float}{for}{goto}{if}{inline}{int}{long}{nullptr}%
+      {register}{restrict}{return}{short}{signed}{sizeof}{static}%
+      {static_assert}{struct}{switch}{thread_local}{true}{typedef}%
+      {typeof}{typeof_unqual}{union}{unsigned}{void}{volatile}{while}%
+      {_Alignas}{_Alignof}{_Atomic}{_BitInt}{_Bool}{_Complex}%
+      {_Decimal128}{_Decimal32}{_Decimal64}{_Generic}{_Imaginary}%
+      {_Noreturn}{_Static_assert}{_Thread_local}
       \_do {\_replthis{\n#1\n}{\z K{#1}}}
    \_replthis{.}{\n.\n}                                                   % numbers
    \_foreach 0123456789


### PR DESCRIPTION
This change contains all keywords defined in ISO/IEC 9899:2018, the current standard, and the latest draft of the next revision in 2023.

The `entry` keyword was mentioned in K&R (1st ed.) as a reserved word for future use. However, it was never defined in ISO C, nor reserved.