### PR TITLE
Use proper \foreach while loading Tikz packages

### DIFF
--- a/optex/pkg/tikz.opm
+++ b/optex/pkg/tikz.opm
@@ -152,6 +152,11 @@
    \_cod
 
 \addto \tikz@startup@env {\let\foreach=\pgffor@foreach}
+\_def\pgfutil@InputIfFileExists#1#2#3{%
+   \pgfutil@IfFileExists {#1}%
+   {\_let\foreach\pgffor@foreach\_input #1\_relax\_let\foreach\_optexforeach #2}%
+   {#3}%
+}
 \_let\.foreach=\pgffor@foreach  % \_pgf_foreach is \pgffor@foreach
 \_let\foreach=\_optexforeach    % \foreach is OpTeX's \foreach
 


### PR DESCRIPTION
This could be a solution to #108 .  But I'm not sure this is the best way to deal with it.