### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,26 @@
+name: "Check changes"
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  check-optex:
+    runs-on: ubuntu-latest
+    container:
+      image: texlive/texlive:latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Update TeX Live
+        run: |
+          tlmgr update --self --all
+          luatex --credits
+
+      - name: Build and test
+        run: |
+          cd optex
+          make format
+          make test


### PR DESCRIPTION
This change enables a CI workflow for OpTeX.

It builds OpTeX with the latest TeX Live and typeset demo files on every pull request. You can download the typeset files for three days if succeeded.

I hope this will become the basis of more advanced automatic testing on OpTeX and prevent accidental breakages.