### PR TITLE
Add free and open typefaces from indestructible type*

### DIFF
--- a/optex/base/f-besley.opm
+++ b/optex/base/f-besley.opm
@@ -1,0 +1,46 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [Besley] \Besley {Besley* antique slab serif}
+        {\caps \allsc \nocaps \cond \narrow}
+        {\rm \bf \it \bi \mf \mi \ef \ei \kf \ki} {Schola}
+        {[Besley-Regular]}
+        {\_def\_fontnamegen {[Besley\_subV-\_currV]:script=latn;\_capsV\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Modifiers (width):^^J
+ \cond ....... Condensed variants^^J
+ \narrow ..... Narrow variants^^J
+Modifiers (small caps):^^J
+ \caps ....... Caps and small caps^^J
+ \allsc ...... Small caps only^^J
+ \nocaps ..... No small caps^^J
+Extended variants:^^J
+ \mf, \mi .... Medium, MediumItalic^^J
+ \ef, \ei .... ExtraBold, ExtraBoldItalic^^J
+ \kf, \ki .... Black, BlackItalic^^J
+}}
+
+\_moddef \resetmod {\_fsetV sub={},caps={} \_fvars Regular Bold Italic BoldItalic }
+\_moddef \cond     {\_fsetV sub=Condensed }
+\_moddef \narrow   {\_fsetV sub=Narrow }
+\_moddef \caps     {\_fsetV caps=+smcp;\_ffonum; }
+\_moddef \allsc    {\_fsetV caps=+smcp;+c2sc;\_ffonum; }
+\_moddef \nocaps   {\_fsetV caps={} }
+
+\_moddef  \medium {\_fvars Medium ExtraBold MediumItalic ExtraBoldItalic }
+\_moddef  \black  {\_fvars Black  .         BlackItalic  . }
+\_private \medium ;
+\_private \black ;
+
+\_famvardef \mf {\_medium \_rm}
+\_famvardef \mi {\_medium \_it}
+\_famvardef \ef {\_medium \_bf}
+\_famvardef \ei {\_medium \_bi}
+\_famvardef \kf {\_black  \_rm}
+\_famvardef \ki {\_black  \_it}
+
+\_initfontfamily
+
+\loadmath{[texgyreschola-math]}
+
+\_endcode

--- a/optex/base/f-bodonimoda.opm
+++ b/optex/base/f-bodonimoda.opm
@@ -1,0 +1,43 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [BodoniModa] \BodoniModa {No-compromises Bodoni for the digital age}
+        {\caps \allsc \nocaps}
+        {\rm \bf \it \bi \mf \mi \ef \ei \kf \ki} {}
+        {[BodoniModa11pt-Regular]}
+        {\_def\_fontnamegen {[\_optname{bm}pt-\_currV]:script=latn;\_capsV\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Modifiers (small caps):^^J
+ \caps ....... Caps and small caps^^J
+ \allsc ...... Small caps only^^J
+ \nocaps ..... No small caps^^J
+Extended variants:^^J
+ \mf, \mi .... Medium, MediumItalic^^J
+ \ef, \ei .... ExtraBold, ExtraBoldItalic^^J
+ \kf, \ki .... Black, FatfaceItalic^^J
+}}
+
+\_regoptsizes bm BodoniModa?
+    06 <8.5 11 <13.5 16 <20 24 <30 36 <42 48 <60 72 <84 96 <*
+
+\_moddef \resetmod {\_fsetV caps={} \_fvars Regular Bold Italic BoldItalic }
+
+\_moddef \caps     {\_fsetV caps=+smcp;\_ffonum; }
+\_moddef \allsc    {\_fsetV caps=+smcp;+c2sc;\_ffonum; }
+\_moddef \nocaps   {\_fsetV caps={} }
+
+\_moddef \medium   {\_fvars Medium  ExtraBold MediumItalic  ExtraBoldItalic }
+\_moddef \black    {\_fvars Black   .         FatfaceItalic . }
+\_private \medium ;
+\_private \black ;
+
+\_famvardef \mf {\_medium \_rm}
+\_famvardef \mi {\_medium \_it}
+\_famvardef \ef {\_medium \_bf}
+\_famvardef \ei {\_medium \_bi}
+\_famvardef \kf {\_black  \_rm}
+\_famvardef \ki {\_black  \_it}
+
+\_initfontfamily
+
+\_endcode

--- a/optex/base/f-draftingmono.opm
+++ b/optex/base/f-draftingmono.opm
@@ -1,0 +1,30 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [DraftingMono] \DraftingMono {Drafting* Mono monospaced}
+        {\caps \allsc \nocaps \thin \light \medium} {\rm \bf \it \bi} {}
+        {[DraftingMono-Regular]}
+        {\_def\_fontnamegen {[DraftingMono-\_currV]:script=latn;\_capsV\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Modifiers (weight)^^J
+ \thin ..... \rm, \it: Thin, \bf, \bi: Light^^J
+ \light .... \rm, \it: Light, \bf, \bi: Medium^^J
+ \medium ... \rm, \it: Medium, \bf, \bi: Bold^^J
+Modifiers: (small caps)^^J
+ \caps ..... Caps and small caps^^J
+ \allsc .... Small caps only^^J
+ \nocaps ... No small caps^^J
+}}
+
+\_moddef \resetmod {\_fsetV caps={} \_fvars Regular Bold Italic BoldItalic }
+\_moddef \caps     {\_fsetV caps=+smcp; }
+\_moddef \allsc    {\_fsetV caps=+smcp;+c2sc; }
+\_moddef \nocaps   {\_fsetV caps={} }
+
+\_moddef \thin   {\_fvars Thin   Light  ThinItalic   LightItalic }
+\_moddef \light  {\_fvars Light  Medium LightItalic  MediumItalic }
+\_moddef \medium {\_fvars Medium Bold   MediumItalic BoldItalic }
+
+\_initfontfamily
+
+\_endcode

--- a/optex/base/f-jost.opm
+++ b/optex/base/f-jost.opm
@@ -1,0 +1,32 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [Jost] \Jost {Jost* geometric sans-serif}
+        {\hairline \thin \light \medium}
+        {\rm \bf \it \bi \kf \ki} {}
+        {[Jost-400-Book]}
+        {\_def\_fontnamegen {[Jost-\_currV]:script=latn;\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Modifiers (weight):^^J
+ \hairline ... \rm, \it: Hairline, \bf, \bi: Book^^J
+ \thin ....... \rm, \it: Thin, \bf, \bi: Medium^^J
+ \light ...... \rm, \it: Light, \bf, \bi: SemiBold^^J
+ \medium ..... \rm, \it: Medium, \bf, \bi: Hevy^^J
+Extended Variants:^^J
+ \kf, \ki .... Black, BlackItalic^^J
+}}
+
+\_moddef \resetmod {\_fvars 400-Book     700-Bold   400-BookItalic     700-BoldItalic }
+\_moddef \hairline {\_fvars 100-Hairline 400-Book   100-HairlineItalic 400-BookItalic }
+\_moddef \thin     {\_fvars 200-Thin     500-Medium 200-ThinItalic     500-MediumItalic }
+\_moddef \light    {\_fvars 300-Light    600-Semi   300-LightItalic    600-SemiItalic }
+\_moddef \medium   {\_fvars 500-Medium   800-Hevy   500-MediumItalic   800-HevyItalic }
+\_moddef \black    {\_fvars 900-Black    .          900-BlackItalic    . }
+\_private \black ;
+
+\_famvardef \kf {\_black\_rm}
+\_famvardef \ki {\_black\_it}
+
+\_initfontfamily
+
+\_endcode

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -7,7 +7,7 @@
 \_faminfo [Catalogue] {Catalogue of all registered font families} {fonts-catalog} {}
 \_famalias [Catalog]
 
-\_famsrc {TeXlive}
+\_famsrc {CTAN}
 \_famtext {Computer Modern like family:}
 
 \_famfrom {GUST}
@@ -204,7 +204,7 @@
    { -,\light,\book, \caps, \caps\book: {\rm\bf\it\bi} -:{\stencil} }
 \_famalias [CTU Technika]
 
-\_famsrc {TeXlive}
+\_famsrc {CTAN}
 \_famfrom {Bitstream, Andrey V. Panov, Michael Sharpe}
 \_faminfo [XCharter] {An extension of Bitstream Charter} {f-xcharter}
    { -,\slant,\caps,\caps\slant: {\rm\bf\it\bi} }

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -58,6 +58,12 @@
      \allsc,\narrow\allsc,\cond\allsc: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki} }
 \_famalias [Besley]
 
+\_faminfo [Drafting* Mono] {Monospaced typeface family with small caps} {f-draftingmono}
+   { \thin,\light,-,\medium: {\rm\bf\it\bi}
+     \thin\caps,\light\caps,\caps,\medium\caps: {\rm\bf\it\bi}
+     \thin\allsc,\light\allsc,\allsc,\medium\allsc: {\rm\bf\it\bi} }
+\_famalias [DraftingMono]
+
 \_famsrc {CTAN}
 \_famtext {Other fonts:}
 

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -58,6 +58,10 @@
      \allsc,\narrow\allsc,\cond\allsc: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki} }
 \_famalias [Besley]
 
+\_faminfo [Bodoni*] {No-compromises Bodoni for the digital age} {f-bodonimoda}
+   { -,\caps,\allsc: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki} }
+\_famalias [Bodoni] \_famalias [BodoniModa]
+
 \_faminfo [Drafting* Mono] {Monospaced typeface family with small caps} {f-draftingmono}
    { \thin,\light,-,\medium: {\rm\bf\it\bi}
      \thin\caps,\light\caps,\caps,\medium\caps: {\rm\bf\it\bi}

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -48,6 +48,17 @@
    { -,\caps: {\rm\bf\it\bi} }
 \_famalias [Courier]
 
+\_famsrc {https://indestructibletype.com/}
+\_famtext {Typefaces from indestructible type*}
+
+\_famfrom {Owen Earl, indestructible type*}
+\_faminfo [Besley*] {Antique slab serif, inspired by Robert Besley's Clarendon} {f-besley}
+   { -,\narrow,\cond: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki}
+     \caps,\narrow\caps,\cond\caps: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki}
+     \allsc,\narrow\allsc,\cond\allsc: {\rm\mf\bf\ef\kf\it\mi\bi\ei\ki} }
+\_famalias [Besley]
+
+\_famsrc {CTAN}
 \_famtext {Other fonts:}
 
 \_famfrom{Antonis Tsolomitis}

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -64,6 +64,10 @@
      \thin\allsc,\light\allsc,\allsc,\medium\allsc: {\rm\bf\it\bi} }
 \_famalias [DraftingMono]
 
+\_faminfo [Jost*] {A modern geometric sans-serif} {f-jost}
+   { \hairline,\thin,\light,-,\medium: {\rm\bf\it\bi} -: {\kf\ki} }
+\_famalias [Jost]
+
 \_famsrc {CTAN}
 \_famtext {Other fonts:}
 


### PR DESCRIPTION
Website: https://indestructibletype.com/
GitHub: https://github.com/indestructible-type

- [x] [Besley*](https://github.com/indestructible-type/Besley) (slab serif)
- [x] [Bodoni*](https://github.com/indestructible-type/Bodoni) (Bodoni reproduction, supporting optical sizes)
- [x] [Drafting* Mono](https://github.com/indestructible-type/Drafting) (monospaced)
- [x] [Jost*](https://github.com/indestructible-type/Jost) (geometric sans-serif)