### PR TITLE
Add basic language data for Estonian

### DIFF
--- a/optex/base/lang-data.opm
+++ b/optex/base/lang-data.opm
@@ -157,6 +157,13 @@
 \_sdef{_mt:today:pt}{\_the\_day~de \_mtext{m\_the\_month}~ de \_the\_year}
 % todo
 
+\_langdata et {Estonian} % ------------------------------------------------
+\_langw et  Peatükk      Tabel       Joonis      Teema
+\_monthw et jaanuar veebruar märts aprill mai juuni
+            juuli august september oktoober november detsember
+\_sdef{_mt:today:et}{\_the\day.~\_mtext{m\_the\_month} \_the\_year}
+\_quotationmarks{„“„“}
+
 \_endcode
 
 2022-10-11: \postexhyphenchar setting added to cs and sk languages


### PR DESCRIPTION
I've added basic language data for Estonian, only the fields that made sense. Note that I've made \"text" and \'text' be equivalent in Estonian. I've explained why this is in the commit message. Alas, I couldn't figure out how to test these changes since (as I understand it) the language data is lazy-loaded from the TeX distribution.