### PR TITLE
Extend  `\_inkdefs`

### DIFF
--- a/optex/base/graphics.opm
+++ b/optex/base/graphics.opm
@@ -59,6 +59,11 @@
   \_def\rotatebox#1#2{\_pdfrotate{#1}#2}%
   \_def\lineheight#1{}%
   \_def\setlength#1#2{}%
+  \_def\transparent#1{}%
+  % Inkscape may generate \textbf{\textit{\textsc{TEXT}}}
+  \_def\textbf#1{\_begingroup\_let\_it\_bi\_bf #1\_endgroup}%
+  \_def\textit#1{\_begingroup\_it #1\_endgroup}%
+  \_def\textsl#1{\_begingroup\_trycs{slant}{}\_it #1\_endgroup}%
 }
 \_public \inkinspic ;
 

--- a/optex/base/graphics.opm
+++ b/optex/base/graphics.opm
@@ -59,7 +59,7 @@
   \_def\rotatebox#1#2{\_pdfrotate{#1}#2}%
   \_def\lineheight#1{}%
   \_def\setlength#1#2{}%
-  \_def\transparent#1{}%
+  \_def\transparent#1{\_ea\_transparency\_expanded{\_expr[0]{(1-.5)*255}} }%
   % Inkscape may generate \textbf{\textit{\textsc{TEXT}}}
   \_def\textbf#1{\_begingroup\_let\_it\_bi\_bf #1\_endgroup}%
   \_def\textit#1{\_begingroup\_it #1\_endgroup}%


### PR DESCRIPTION
# Commit: Extend  `\_inkdefs`
- add \textbf
- add \textit
- add \textsc
- add \transparent

These macros may be generated by Inkscape's `latex-text-renderer.cpp`.

# Additional notes

The relevant code can be seen here 
<https://gitlab.com/inkscape/inkscape/-/blob/master/src/extension/internal/latex-text-renderer.cpp#L390>

------------

Test case:

```tex
\fontfam[pagella]

\inkinspic{figure.pdf}

\bye
```

I'm using Inkscape 1.1.2 (0a00cf5339, 2022-02-04)
with 
``
inkscape figure.svg --export-type=pdf --export-latex -o figure.pdf      
``

Inkscapes generates 
````tex
  \begin{picture}(1,0.62019123)%
    \lineheight{1}%
    \setlength\tabcolsep{0pt}%
    \put(0,0){\includegraphics[width=\unitlength,page=1]{figure.pdf}}%
    \put(0.80999305,0.15562135){\color[rgb]{1,0.4,0}\makebox(0,0)[lt]{\lineheight{1.25}\smash{\begin{tabular}[t]{l}Some\\\textbf{\textit{tex}}\textbf{\textit{t}}\end{tabular}}}}%
    \put(0.08211842,0.48438098){\color[rgb]{0,0,0}\makebox(0,0)[lt]{\lineheight{1.25}\smash{\begin{tabular}[t]{l}regular, \textbf{bold},\\\textit{italic}, \textbf{\textit{bold-italic }}\\\end{tabular}}}}%
    \put(0.05959094,0.13101){\color[rgb]{0,0.50196078,0}\makebox(0,0)[lt]{\lineheight{1.25}\smash{\begin{tabular}[t]{l}\textsl{slanted, }\textbf{bold}\\\textbf{\textsl{bold slanted}}\end{tabular}}}}%
    \put(0.60685555,0.51537681){\color[rgb]{0,0,0}\transparent{0.40999392}\makebox(0,0)[lt]{\lineheight{1.25}\smash{\begin{tabular}[t]{l}semi-transparent\end{tabular}}}}%
  \end{picture}%
````

I've attached the SVG file.

[figure.zip](https://github.com/olsak/OpTeX/files/10974337/figure.zip)

