### PR TITLE
Clara serif font family added.

### DIFF
--- a/optex/base/f-clara.opm
+++ b/optex/base/f-clara.opm
@@ -7,7 +7,7 @@
 
 \_wlog{\_detokenize{%
 Modifiers:^^J
- \caps ...... caps & small caps (\rm, simple alphabet only!)^^J
+ \caps ...... caps & small caps (only \rm with simple alphabet!)^^J
 }}
 
 % Modes

--- a/optex/base/f-clara.opm
+++ b/optex/base/f-clara.opm
@@ -21,3 +21,4 @@ Modifiers:^^J
 \_loadboldmath {[XITSMath-Bold]} \to {[XITSMath-Regular]}
 
 \_endcode
+

--- a/optex/base/f-clara.opm
+++ b/optex/base/f-clara.opm
@@ -1,0 +1,23 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [Clara] \Clara {Clara, a serif font family}
+   {\caps} {\rm \bf \it \bi}
+   {XITSMath} {[clarar]}
+   {\_def\_fontnamegen {[clara\_currV]:\_capsV\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Modifiers:^^J
+ \caps ...... caps & small caps (\rm, simple alphabet only!)^^J
+}}
+
+% Modes
+\_moddef \resetmod {\_fsetV caps={} \_fvars r b i bi }
+\_moddef \caps     {\_fsetV caps=+smcp; } % onum; set by smcp; feature
+\_moddef \nocaps   {\_fsetV caps={} }
+
+\_initfontfamily % New font family must be initialized
+
+\_loadmath {[XITSMath-Regular]}
+\_loadboldmath {[XITSMath-Bold]} \to {[XITSMath-Regular]}
+
+\_endcode

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -256,6 +256,9 @@
 \_faminfo [OldStandard] {inspired by a typeface most commonly used in old books} {f-oldstandard}
    { -,\caps: {\rm\bf\it\bi} }
 
+\_famfrom {Séamas Ó Brógáin}
+\_faminfo [Clara] {Clara, a serif font family} {f-clara}
+   { -: {\rm\bf\it\bi} \caps: {\rm} }
 
 \_endcode
 


### PR DESCRIPTION
Clara is a font family created specially by Séamas Ó Brógáin
for printing the book "A Dictionary of Editing" in 2015.
The font is a little heavier, but it's good usable and readable.
It also supports the Greek and Cyrillic alphabets, so it can be
called multilingual. The glyphs have correct accents and kerning.
Czech, for example.

The best matching math font is XITSMath. The only difference
is in few glyphs, but the others are the same or very similar.
It has a little less x-height, but only a little.

Maybe a better description would be good!

It is available from CTAN:
https://ctan.org/pkg/clara
