### PR TITLE
Fix typs in doc and setting \matheqdirmode and \breakafterdirmode to 1

### DIFF
--- a/optex/base/lang-decl.opm
+++ b/optex/base/lang-decl.opm
@@ -157,7 +157,7 @@
    example:
    \begtt
    \_preplangmore ru {\_frenchspacing \_setff{script=cyrl}\selectcyrlfont}
-   \_addto\_langdefaut {\_setff{}\selectlatnfont}
+   \_addto\_langdefault {\_setff{}\selectlatnfont}
    \endtt
    The macros `\selectcyrlfont` and `\selectlatnfont` are not defined in
    \OpTeX/. If you follow this example, you have to define them after your

--- a/optex/base/parameters.opm
+++ b/optex/base/parameters.opm
@@ -57,6 +57,17 @@
 \_splittopskip=10pt
 
    \_doc -----------------------------
+   The following two registers were introduced to fix a couple of bugs
+   in the \LuaTeX/ engine. When `\matheqdirmode` is positive short
+   skip detection around display equations will work with right to left 
+   typesetting. When `\breakafterdirmode` is set to 1 a glue after a dir
+   node will not be ignored.
+   \_cod -----------------------------
+
+\_matheqdirmode=1
+\_breakafterdirmode=1
+
+   \_doc -----------------------------
    \secc Plain \TeX/ registers
    Allocate registers that are used just like in plain \TeX/.\nl
    \`\smallskipamount`, \`\medskipamount`, \`\bigskipamount`,

--- a/optex/demo/op-slides.tex
+++ b/optex/demo/op-slides.tex
@@ -25,7 +25,7 @@
 
 \sec Basics
 
-* The the simple document looks like:
+* A simple document looks like:
 
 \begtt
 \slides       % style initialized


### PR DESCRIPTION
See section 3.3.3 and 7.5.3 of LuaTeX's manual. 