### PR TITLE
Patch `\newcatcodetable` before loading minim-alloc

### DIFF
--- a/optex/pkg/minim.opm
+++ b/optex/pkg/minim.opm
@@ -93,6 +93,18 @@
 }
 
    \_doc
+   Both \LaTeX/ and the minim inspired catcode table allocators initialize the
+   catcode tables with `\initcatcodetable` (i.e. ini\TeX/ catcodes). \OpTeX/
+   merely allocates the registers. \LuaTeX/ doesn't allow to activate
+   unitialized catcode table, therefore activation with either
+   `\initcatcodetable` or `\savecatcodetable` is necessary before use. To
+   ensure compatibility with foreign macros, we also issue `\initcatcodetable`
+   on allocation in the public version of `\newcatcodetable`.
+   \_cod
+
+\_def\newcatcodetable#1{\_newcatcodetable#1\_initcatcodetable#1}
+
+   \_doc
    We also get PDF resources out of the way now. Minim is ready to use \OpTeX's
    PDF resource management, but also has compatibility layer for PGF, which is
    not needed in \OpTeX/. We prevent loading the problematic \TeX/ file.
@@ -105,18 +117,6 @@
    \_cod
 
 \input minim-alloc
-
-   \_doc
-   Both \LaTeX/ and the minim inspired catcode table allocators initialize the
-   catcode tables with `\initcatcodetable` (i.e. ini\TeX/ catcodes). \OpTeX/
-   merely allocates the registers. \LuaTeX/ doesn't allow to activate
-   unitialized catcode table, therefore activation with either
-   `\initcatcodetable` or `\savecatcodetable` is necessary before use. To
-   ensure compatibility with foreign macros, we also issue `\initcatcodetable`
-   on allocation in the public version of `\newcatcodetable`.
-   \_cod
-
-\_def\newcatcodetable#1{\_newcatcodetable#1\_initcatcodetable#1}
 
    \_doc
    By now, the Knuthian allocators are dealt with. \eTeX/ global and local


### PR DESCRIPTION
In the latest release minim actually uses `\newcatcodetable` in minim-alloc.tex. This means that it still uses the standard OpTeX definition (which doesn't initialize the catcode table), but it expects the initialization.

We solve this by doing the patch to `\newcatcodetable` _before_ loading minim-alloc.tex. It should have probably been done this way right from the beginning, it just didn't manifest.