### PR TITLE
Make `\bracedparam` more robust

### DIFF
--- a/optex/base/more-macros.opm
+++ b/optex/base/more-macros.opm
@@ -145,15 +145,15 @@
    \_cod -----------------------------
 
 \_def\_eoldef #1{\_def #1{\_begingroup \_catcode`\^^M=12 \_eoldefA #1}%
-   \_ea\_def\_csname _bracedparam:\_csstring #1\_endcsname}
+   \_ea\_def\_csname _eol:\_csstring #1\_endcsname}
 \_catcode`\^^M=12 %
-\_def\_eoldefA #1#2^^M{\_endgroup\_csname _bracedparam:\_csstring #1\_endcsname{#2}}%
+\_def\_eoldefA #1#2^^M{\_endgroup\_csname _eol:\_csstring #1\_endcsname{#2}}%
 \_normalcatcodes %
 
 \_eoldef\_skiptoeol#1{}
-\_def\_bracedparam#1{\_ifcsname _bracedparam:\_csstring #1\_endcsname\_else%
-   \_errmessage {\_bslash bracedparam: \_bslash _bracedparam:\_csstring #1 must be defined}\_fi%
-   \_csname _bracedparam:\_csstring #1\_ea \_endcsname}
+\_def\_bracedparam#1{\_ifcsname _eol:\_csstring #1\_endcsname\_else%
+   \_errmessage {\_bslash bracedparam: \_bslash _eol:\_csstring #1 must be defined}\_fi%
+   \_csname _eol:\_csstring #1\_ea \_endcsname}
 
 \_public \eoldef \skiptoeol \bracedparam ;
 

--- a/optex/base/more-macros.opm
+++ b/optex/base/more-macros.opm
@@ -135,27 +135,26 @@
    This is the parameter `#1` which can be used in the `<replacement text>`.
    The catcode of the `\endlinechar` is reset temporarily when the parameter is scanned. 
 
-   The macro defined by `\eoldef` cannot be used with its parameter inside
-   other macros because the catcode dancing is not possible here. But the
-   \`\bracedparam``\macro{<parameter>}` can be used here. The `\bracedparam`
-   is a prefix that re-sets temporarily the `\macro` to a `\macro` with
-   normal one parameter.
+   A macro defined by `\eoldef` cannot be used inside of another macro because
+   the catcode dancing is not possible there. However, the \`\bracedparam``\macro{<parameter>}`
+   can be used instead. The `\bracedparam` is a prefix that re-sets temporarily the
+   `\macro` to a `\macro` with a single normal parameter.
 
    The \`\skiptoeol` macro reads the text to the end of the current line 
    and ignores it.
    \_cod -----------------------------
 
 \_def\_eoldef #1{\_def #1{\_begingroup \_catcode`\^^M=12 \_eoldefA #1}%
-   \_ea\_def\_csname _\_csstring #1:M\_endcsname}
+   \_ea\_def\_csname _bracedparam:\_csstring #1\_endcsname}
 \_catcode`\^^M=12 %
-\_def\_eoldefA #1#2^^M{\_endgroup\_csname _\_csstring #1:M\_endcsname{#2}}%
+\_def\_eoldefA #1#2^^M{\_endgroup\_csname _bracedparam:\_csstring #1\_endcsname{#2}}%
 \_normalcatcodes %
 
 \_eoldef\_skiptoeol#1{}
-\_def\_bracedparam#1{\_ifcsname _\_csstring #1:M\_endcsname
-    \_csname _\_csstring #1:M\_ea \_endcsname
-    \_else \_csname _in\_csstring #1\_ea \_endcsname \_fi
-}
+\_def\_bracedparam#1{\_ifcsname _bracedparam:\_csstring #1\_endcsname\_else%
+   \_errmessage {\_bslash bracedparam: \_bslash _bracedparam:\_csstring #1 must be defined}\_fi%
+   \_csname _bracedparam:\_csstring #1\_ea \_endcsname}
+
 \_public \eoldef \skiptoeol \bracedparam ;
 
    \_doc -----------------------------

--- a/optex/base/prefixed.opm
+++ b/optex/base/prefixed.opm
@@ -97,8 +97,16 @@
 \_def \_nspublic {\_xargs \_nspublicA}
 \_def \_nspublicA #1{%
    \_checkexists \_nspublic {\_pkglabel _\_csstring #1}%
-   \_ea\_newpublic \_ea\_let \_ea#1\_csname \_pkglabel _\_csstring #1\_endcsname
-}
+   \_ea\_newpublic \_ea\_let \_ea#1\_csname \_pkglabel _\_csstring #1\_endcsname%
+   % export _bracedparam:<_pkglabel>_<#1> if present
+   \_ifcsname _bracedparam:\_pkglabel _\_csstring #1\_endcsname%
+      \_ifcsname _bracedparam:\_csstring #1\_endcsname%
+         \_opwarning{\_bslash _bracedparam:\_csstring #1 is redefined%
+         \_ifx\_pkglabel\_empty \_else\_space by the \_ea\_ignoreit\_pkglabel\_space package\_fi}%
+      \_fi%
+      \_slet{_bracedparam:\_csstring #1}{_bracedparam:\_pkglabel _\_csstring #1}%
+   \_fi}
+
 \_def \_nsprivate {\_xargs \_nsprivateA}
 \_def \_nsprivateA #1{%
    \_checkexists \_nsprivate {\_csstring #1}%

--- a/optex/base/prefixed.opm
+++ b/optex/base/prefixed.opm
@@ -96,16 +96,11 @@
 }
 \_def \_nspublic {\_xargs \_nspublicA}
 \_def \_nspublicA #1{%
-   \_checkexists \_nspublic {\_pkglabel _\_csstring #1}%
-   \_ea\_newpublic \_ea\_let \_ea#1\_csname \_pkglabel _\_csstring #1\_endcsname%
-   % export _bracedparam:<_pkglabel>_<#1> if present
-   \_ifcsname _bracedparam:\_pkglabel _\_csstring #1\_endcsname%
-      \_ifcsname _bracedparam:\_csstring #1\_endcsname%
-         \_opwarning{\_bslash _bracedparam:\_csstring #1 is redefined%
-         \_ifx\_pkglabel\_empty \_else\_space by the \_ea\_ignoreit\_pkglabel\_space package\_fi}%
-      \_fi%
-      \_slet{_bracedparam:\_csstring #1}{_bracedparam:\_pkglabel _\_csstring #1}%
-   \_fi}
+  \_checkexists \_nspublic {\_pkglabel _\_csstring #1}%
+  \_ea\_newpublic \_ea\_let \_ea#1\_csname \_pkglabel _\_csstring #1\_endcsname
+  \_ifcsname _eol:\_pkglabel _\_csstring #1\_endcsname % defined by \eoldef
+     \_slet {_eol:\_csstring #1}{_eol:\_pkglabel _\_csstring #1}\_fi
+}
 
 \_def \_nsprivate {\_xargs \_nsprivateA}
 \_def \_nsprivateA #1{%

--- a/optex/base/sections.opm
+++ b/optex/base/sections.opm
@@ -31,8 +31,8 @@
 \_let\_intit=\_printtit  % for backward compatibility
 
 
-\_sdef{_bracedparam:_tit}#1{\_printtit{#1}} % used by \bracedparam
-\_slet{_bracedparam:tit}{_bracedparam:_tit}
+\_sdef{_eol:_tit}#1{\_printtit{#1}} % used by \bracedparam
+\_slet{_eol:tit}{_eol:_tit}
 
 \_public \tit ;
 
@@ -207,9 +207,9 @@
 }
 
 % used by \bracedparam
-\_sdef{_bracedparam:_chap}#1{\_inchap{#1}} \_slet{_bracedparam:chap}{_bracedparam:_chap}
-\_sdef{_bracedparam:_sec}#1{\_insec{#1}}   \_slet{_bracedparam:sec}{_bracedparam:_sec}
-\_sdef{_bracedparam:_secc}#1{\_insecc{#1}} \_slet{_bracedparam:secc}{_bracedparam:_secc}
+\_sdef{_eol:_chap}#1{\_inchap{#1}} \_slet{_eol:chap}{_eol:_chap}
+\_sdef{_eol:_sec}#1{\_insec{#1}}   \_slet{_eol:sec}{_eol:_sec}
+\_sdef{_eol:_secc}#1{\_insecc{#1}} \_slet{_eol:secc}{_eol:_secc}
 
 \_public \chap \sec \secc ;
 
@@ -338,7 +338,7 @@
    \_noindent{\_bf #1}\_vadjust{\_nobreak}\_nl\_ignorepars}
 \_def\_ignorepars{\_isnextchar\_par{\_ignoresecond\_ignorepars}{}}
 
-\_slet{_bracedparam:seclp}{_bracedparam:_seclp} % used by \bracedparam
+\_slet{_eol:seclp}{_eol:_seclp} % used by \bracedparam
 
 \_public \secl ;
 

--- a/optex/base/sections.opm
+++ b/optex/base/sections.opm
@@ -28,7 +28,11 @@
    \_nobreak\_bigskip
 }
 \_def\_tit{\_scantoeol\_printtit}
-\_let\_intit=\_printtit  % used by \bracedparam
+\_let\_intit=\_printtit  % for backward compatibility
+
+
+\_sdef{_bracedparam:_tit}#1{\_printtit{#1}} % used by \bracedparam
+\_slet{_bracedparam:tit}{_bracedparam:_tit}
 
 \_public \tit ;
 
@@ -171,7 +175,8 @@
    First, we read the optional parameter `[<label>]`, if it exists.
    The `\chap`, `\sec` and `\secc` macro reads its parameter using
    \^`\scantoeol`. This causes that they cannot be used inside other macros.
-   Use \^`\_inchap`, \^`\_insec`, and \^`\_insecc` macros directly in such case.
+   In this case use \^`\bracedparam` or use the  \^`\_inchap`, \^`\_insec`,
+   and \^`\_insecc` macros directly.
    \_cod ----------------------------
 
 \_optdef\_chap[]{\_trylabel \_scantoeol\_inchap}
@@ -200,6 +205,12 @@
    \_printsecc{\_scantextokens{#1}}%
    \_resetnonumnotoc
 }
+
+% used by \bracedparam
+\_sdef{_bracedparam:_chap}#1{\_inchap{#1}} \_slet{_bracedparam:chap}{_bracedparam:_chap}
+\_sdef{_bracedparam:_sec}#1{\_insec{#1}}   \_slet{_bracedparam:sec}{_bracedparam:_sec}
+\_sdef{_bracedparam:_secc}#1{\_insecc{#1}} \_slet{_bracedparam:secc}{_bracedparam:_secc}
+
 \_public \chap \sec \secc ;
 
    \_doc ----------------------------
@@ -326,6 +337,8 @@
 \_eoldef\_seclp#1{\_par \_ifnum\_lastpenalty=0 \_removelastskip\_medskip\_fi
    \_noindent{\_bf #1}\_vadjust{\_nobreak}\_nl\_ignorepars}
 \_def\_ignorepars{\_isnextchar\_par{\_ignoresecond\_ignorepars}{}}
+
+\_slet{_bracedparam:seclp}{_bracedparam:_seclp} % used by \bracedparam
 
 \_public \secl ;
 

--- a/optex/base/slides.opm
+++ b/optex/base/slides.opm
@@ -51,7 +51,7 @@
 \_eoldef\_subtit#1{\_vskip20pt {\_leftskip=0pt plus1fill \_rightskip=\_leftskip
    \_subtitfont #1\_nbpar}}
 
-\_slet{_bracedparam:subtit}{_bracedparam:_subtit}
+\_slet{_eol:subtit}{_eol:_subtit}
 
    \_doc -----------------------------
    The \`\pshow``<num>` prints the text in invisible

--- a/optex/base/slides.opm
+++ b/optex/base/slides.opm
@@ -51,6 +51,8 @@
 \_eoldef\_subtit#1{\_vskip20pt {\_leftskip=0pt plus1fill \_rightskip=\_leftskip
    \_subtitfont #1\_nbpar}}
 
+\_slet{_bracedparam:subtit}{_bracedparam:_subtit}
+
    \_doc -----------------------------
    The \`\pshow``<num>` prints the text in invisible
    (transparent) font when \^`\layernum`\code{<}`<num>`.

--- a/optex/base/styles.opm
+++ b/optex/base/styles.opm
@@ -37,7 +37,7 @@
    \_eoldef\_author##1{\_removelastskip\_bigskip
       {\_leftskip=0pt plus1fill \_rightskip=\_leftskip \_it \_noindent ##1\_par}\_nobreak\_bigskip
    }
-   \_slet{_bracedparam:author}{_bracedparam:_author}
+   \_slet{_eol:author}{_eol:_author}
    \_public \author ;
    \_parindent=1.2em \_iindent=\_parindent \_ttindent=\_parindent
    \_footline={\_global\_footline={\_hss\_rmfixed\_folio\_hss}}

--- a/optex/base/styles.opm
+++ b/optex/base/styles.opm
@@ -37,6 +37,7 @@
    \_eoldef\_author##1{\_removelastskip\_bigskip
       {\_leftskip=0pt plus1fill \_rightskip=\_leftskip \_it \_noindent ##1\_par}\_nobreak\_bigskip
    }
+   \_slet{_bracedparam:author}{_bracedparam:_author}
    \_public \author ;
    \_parindent=1.2em \_iindent=\_parindent \_ttindent=\_parindent
    \_footline={\_global\_footline={\_hss\_rmfixed\_folio\_hss}}


### PR DESCRIPTION
Make `\bracedparam` more robust
- change csname from `_<NAME>:M` to `_bracedparam:<NAME>`
- remove the `\cs{_in<NAME>}` special case
- add `\cs{_bracedparam:<NAME>}` for `\chap` and friends
- extend `\nspublic`

--------

# Rationale

1. The existing implementation has some weird edge cases.
2. It's also not very namespace friendly

## Edge cases 

### `\author` does not work

`\author` from `\report` does not work. 

Test case:
```text
\report
\def\maketitle#1#2{\bracedparam\tit{#1}\bracedparam\author{#2}}
\maketitle{Some report}{John Doe should be italic but is not.}
\bye
```

Possible workaround are to use 
* `\bracedparm\_author` -or-
* `\slet{_author:M}{__author:M}`. ("ugly" double underscore)

`\subtit` form `\slides` has the same problem.

### Obscure (silent) errors with typos

Example:

```
\fontfam[lm]
\def\chapter#1{\bracedparam\cahp{#1}} % TYPO `cahp` instead of `chap`
\chapter{Intro.} % -> \relax Intro. (instead of error message that `cahp` is not defined)
\lorem[1-3]
\bye
```

### Extra work necessary when using `\eoldef` in a package

```
%%% example.opm
\_namespace{example}
\_eoldef\.caution#1{\_centerline{\Red\frame{\strut {\bf Caution:} #1}}}
\_nspublic \caution ;
\_endnamespace
%%% 

% WORKS
\caution Unplug device before opening chassis!

% DOES NOT WORK, uses \relax instead of \caution
\bracedparam\caution{Unplug device before chassis!}
```

This can be fixed by adding 

```
\_slet{_caution:M}{__example_caution:M} 
```

However, the double underscore is a bit hard to read IMO.

# Notes

In this pull-request `\bracedparam\foo` will produce
an error message if `_bracedparam:foo` is not defined.

Another approach would be (pseudo code):

```tex
\_def\_bracedparam#1{\_ifcsname _bracedparam:\_csstring #1\_endcsname
   \_cs{_bracedparam:\_csstring #1\_endcsname}\_else
   \_ifcsname \_csstring #1\_endcsname #1\_else
   \_error{Neither \foo nor \_bracedparam:foo is defined}
   \_fi\_fi}
```
