### PR TITLE
Add ConTeXt logo

### DIFF
--- a/optex/base/fonts-resize.opm
+++ b/optex/base/fonts-resize.opm
@@ -5,7 +5,7 @@
    \_doc -----------------------------
    \`\initunifonts` macro extends \LuaTeX's font capabilities,
    in order to be able to load Unicode fonts. Unfortunately, this part of
-   \OpTeX/ depends on the `luaotfload` package, which adapts Con\TeX/t's generic
+   \OpTeX/ depends on the `luaotfload` package, which adapts \ConTeXt's generic
    font loader for plain \TeX/ and \LaTeX. `luaotfload` uses Lua functions
    from \LaTeX's `luatexbase` namespace, we provide our own replacements.
    \^`\initunifonts` sets itself to relax because we don't want to do

--- a/optex/base/logos.opm
+++ b/optex/base/logos.opm
@@ -20,6 +20,18 @@
 
 \_public \TeX \OpTeX \LuaTeX \XeTeX \ignoreslash ;
 
+   \_doc ----------------------------
+   The  \`\ConTeXt` logo is implemented as in the \ConTeXt/ format itself.
+   The kerning between \"Con" and \"\TeX/t" is calculated by measuring the kerning
+   between the letters \"T" and \"e".
+   \_cod ----------------------------
+
+\_protected\_def \_ConTeXt{\_begingroup%
+    Con\_setbox0=\_hbox{T\_kern\_zo e}\_setbox1=\_hbox{Te}{\_kern\_dimexpr\_wd1 -\_wd0}%
+    T\_kern-.1667em\_lower.5ex\_hbox{E}\_kern-.125emXt\_endgroup\_ignoreslash}
+
+\_public \ConTeXt ;
+
    \_doc -----------------------------
    The \`\_slantcorr` macro expands to the slant-correction of the current font. It is
    used to shifting A if the \`\LaTeX` logo is in italic.
@@ -53,6 +65,7 @@
    \_def\TeX{TeX\_ignslash}\_def\OpTeX{OpTeX\_ignslash}%
    \_def\LuaTeX{LuaTeX\_ignslash}\_def\XeTeX{XeTeX\_ignslash}%
    \_def\LaTeX{LaTeX\_ignslash}\_def\OPmac{OPmac\_ignslash}%
+   \_def\ConTeXt{ConTeXt\_ignslash}%
    \_def\CS{CS}\_def\csplain{csplain\_ignslash}%
 }
 \_public \ignslash ;

--- a/optex/demo/op-mathalign.tex
+++ b/optex/demo/op-mathalign.tex
@@ -44,7 +44,7 @@
 \tit Math alignment examples
 
 The document \url{https://www.ntg.nl/maps/34/06.pdf} shows examples how to
-do special math alignments in display mode in ConTeXt (and in \LaTeX/ for
+do special math alignments in display mode in \ConTeXt/ (and in \LaTeX/ for
 comparison). We present the same examples here. They are created in
 \OpTeX/ and the \LaTeX/ source is shown for comparison.
 

--- a/optex/doc/optex-doc.tex
+++ b/optex/doc/optex-doc.tex
@@ -65,7 +65,7 @@ The main goal of \OpTeX/ is:
 If you need to customize your document or you need to use something
 very specific, then you can copy relevant parts of \OpTeX/ macros into your macro
 file and do changes to these macros here. This is a significant difference from
-\LaTeX/ or ConTeXt, which is an attempt to create a new user level with a
+\LaTeX/ or \ConTeXt/, which is an attempt to create a new user level with a
 plenty of non-primitive parameters and syntax hiding \TeX/ internals.
 The macros from \OpTeX/ are simple and straightforward because they solve only
 what is explicitly needed, they do not create a new user level for


### PR DESCRIPTION
This PR adds the `\ConTeXt` logo.

While `Con\TeX/t` seems to works with many fonts the spacing between "Con" and "TeXt" is a bit large
when using Computer/Latin Modern.

![image](https://github.com/olsak/OpTeX/assets/599839/77c3ff40-dc72-4dd4-8a08-3504c1e5f9fa)


