### PR TITLE
minor simplifications to the code

### DIFF
--- a/optex/base/fonts-opmac.opm
+++ b/optex/base/fonts-opmac.opm
@@ -212,7 +212,7 @@
 \_def \_rmfixed {% used in default \footline
    {\_ifdim\_mainfosize=0pt \_mainfosize=10pt \_fi
     \_fontdef\_tenrm{\_setfontsize{at\mainfosize}\_resetmod\_rm}%
-    \_global\_let\_rmfixed=\_tenrm}% next use will be font switch only
+    \_glet\_rmfixed=\_tenrm}% next use will be font switch only
    \_rmfixed
 }
 \_let \rmfixed = \_tenrm % user can redefine it

--- a/optex/base/more-macros.opm
+++ b/optex/base/more-macros.opm
@@ -222,7 +222,7 @@
 \_catcode`!=3 \_catcode`?=3
 \_def\_replstring #1#2#3{%  \replstring #1{stringA}{stringB}
    \_long\_def\_replacestringsA##1#2{\_tmptoks{##1}\_replacestringsB}%
-   \_long\_def\_replacestringsB##1#2{\_ifx!##1\_relax \_else \_tmptoks\_ea{\_the\_tmptoks#3##1}%
+   \_long\_def\_replacestringsB##1#2{\_ifx!##1\_relax \_else \_toksapp\_tmptoks{#3##1}%
                                      \_ea\_replacestringsB\_fi}%
    \_ea\_replacestringsA #1?#2!#2%
    \_long\_def\_replacestringsA##1?{\_tmptoks{##1}\_edef#1{\_the\_tmptoks}}%

--- a/optex/base/others.opm
+++ b/optex/base/others.opm
@@ -117,7 +117,7 @@
       \_def\SetLipsumLanguage##1{}%
       \_def\NewLipsumPar{\_incr\_tmpnum \_sxdef{_lip:\_the\_tmpnum}}%
       \_opinput {lipsum.ltd.tex}%
-      \_global\_let\_lipsumload=\_empty
+      \_glet\_lipsumload=\_empty
    }}}
 \_def\_lipsumdot[#1]{\_lipsumload \_ea\_ea\_ea \_lipsumdotA \_csname _lip:#1\_endcsname.\_fin}
 \_def\_lipsumdotA #1.#2\_fin {#1}

--- a/optex/base/output.opm
+++ b/optex/base/output.opm
@@ -55,7 +55,7 @@
    \_cod -----------------------------
 
 \_newdimen \_xhsize  \_xhsize=\_hsize
-\_def\_setxhsize {\_global\_xhsize=\_hsize \_global\_let\_setxhsize=\_relax}
+\_def\_setxhsize {\_global\_xhsize=\_hsize \_glet\_setxhsize=\_relax}
 
    \_doc -----------------------------
    \`\gpageno` counts pages from one in the whole document
@@ -215,7 +215,7 @@
 
 \_def \_draft {\_pgbackground={\_draftbox{\_draftfont DRAFT}}%
    \_fontdef\_draftfont{\_setfontsize{at10pt}\_bf}%
-   \_global\_let\_draftfont=\_draftfont
+   \_glet\_draftfont=\_draftfont
 }
 \_def \_draftbox #1{\_setbox0=\_hbox{\_setgreycolor{.8}#1}%
    \_kern.5\_vsize \_kern\_voffset \_kern4.5\_wd0

--- a/optex/base/parameters.opm
+++ b/optex/base/parameters.opm
@@ -629,7 +629,7 @@ a register then \OpTeX/ macros still work without change.
 \_endinput
 
 History:
-2023-09-19 ... \matheqdirmode and \breakafterdirmode set (relevant when RTR typesetting)
+2023-09-19 ... \matheqdirmode and \breakafterdirmode set (relevant when RTL typesetting)
 2021-04-13 ... \bibpart added
 2021-04-07 ... \biboptions added, bug from iso690 fixed
 2020-04-04 ... \tabspaces added

--- a/optex/base/plain-macros.opm
+++ b/optex/base/plain-macros.opm
@@ -54,9 +54,9 @@
 % since this allows, for example, `\let\_par=\cr \obeylines \halign{...'
 {\_catcode`\^^M=13 % these lines must end with %
   \_gdef\_obeylines{\_catcode`\^^M=13\_let^^M\_par}%
-  \_global\_let^^M=\_par} % this is in case ^^M appears in a \write
+  \_glet^^M=\_par} % this is in case ^^M appears in a \write
 \_def\_obeyspaces{\_catcode`\ =13 }
-{\_obeyspaces\_global\_let =\_space}
+{\_obeyspaces\_glet =\_space}
 \_public \obeylines \obeyspaces ;
 
    \_doc -----------------------------

--- a/optex/base/references.opm
+++ b/optex/base/references.opm
@@ -35,7 +35,7 @@
    `\_wref\_Xlabel{<label>}{<text>}`.
    \_cod ----------------------------
 
-\_def\_label[#1]{\_isempty{#1}\_iftrue \_global\_let \_lastlabel=\_undefined
+\_def\_label[#1]{\_isempty{#1}\_iftrue \_glet \_lastlabel=\_undefined
   \_else \_isdefined{l0:#1}%
      \_iftrue \_slideshook\_opwarning{Duplicated label [#1], ignored}\_else \_xdef\_lastlabel{#1}\_fi
   \_fi \_ignorespaces
@@ -47,7 +47,7 @@
      \_printlabel\_lastlabel
      \_ewref \_Xlabel {{\_lastlabel}{#1}}%
      \_sxdef{_lab:\_lastlabel}{#1}\_sxdef{l0:\_lastlabel}{}%
-     \_global\_let\_lastlabel=\_undefined
+     \_glet\_lastlabel=\_undefined
   \_fi
 }
 \_public \label \wlabel ;

--- a/optex/base/table.opm
+++ b/optex/base/table.opm
@@ -195,8 +195,8 @@
 \_def\_addtabitemx{\_ifnum\_colnum>0
    \_addtabdata{&}\_addto\_ddlinedata{&\_dditem}\_fi
    \_advance\_colnum by1 \_let\_tmpa=\_relax
-   \_ifnum\_colnum>1 \_ea\_addtabdata\_ea{\_ea\_colnum\_the\_colnum\_relax}\_fi}
-\_def\_addtabdata#1{\_tabdata\_ea{\_the\_tabdata#1}}
+   \_ifnum\_colnum>1 \_etoksapp\_tabdata{\_colnum\_the\_colnum\_relax}\_fi}
+\_def\_addtabdata{\_toksapp\_tabdata}
 
    \_doc -----------------------------
    This code converts `||` or `|` from `\table` <declaration> to the <converted declaration>.

--- a/optex/base/verbatim.opm
+++ b/optex/base/verbatim.opm
@@ -208,7 +208,7 @@
    \_def\_tmpb{#1}%  cmds used in local group
    \_ifx\_vifilename\_tmpa \_else
       \_openin\_vifile={#3}%
-      \_global\_viline=0 \_global\_let\_vifilename=\_tmpa
+      \_global\_viline=0 \_glet\_vifilename=\_tmpa
       \_ifeof\_vifile
          \_opwarning{\_string\verbinput: file "#3" unable to read}
          \_ea\_ea\_ea\_skiptorelax

--- a/optex/doc/optex-doc.tex
+++ b/optex/doc/optex-doc.tex
@@ -4,7 +4,6 @@
 % (three times) to generate OpTeX documentation including references and the index. 
 
 \load [doc.opm]  \let\enddocument=\endinput
-\let\_catcodedot=\relax \catcode`\.=12 % we are not using \.foo sequences
 
 \typosize[10/12]  % Main size (used in techdoc)
 


### PR DESCRIPTION
This PR will: 
* replace `\_global\_let` with `\_glet`, which is a tiny bit faster and a bit shorter
* will make use of `\toksapp` to simplify the code a bit
* remove a line regarding `\_catcodedot` from `optex-doc` (this macro was removed)
* fix a typo 