### PR TITLE
Allow multiple callbacks with the same description

### DIFF
--- a/optex/base/optex.lua
+++ b/optex/base/optex.lua
@@ -235,12 +235,6 @@ function callback.add_to_callback(name, fn, description)
         err("missing description when adding a callback to '%s'", name)
     end
 
-    for _, desc in ipairs(callback_description[name] or {}) do
-        if desc == description then
-            err("for callback '%s' there already is '%s' added", name, description)
-        end
-    end
-
     if type(fn) ~= "function" then
         err("expected Lua function to be added as '%s' for callback '%s'", description, name)
     end


### PR DESCRIPTION
This cautious check for multiple entries was added in last commit, and it turned out to be problematic with our `\mathsbon` callback, which can be activated multiple times in nested `\load`s (see #180).

While it seems better to me, to be proactive about the checks, LuaLaTeX also seems to allow duplicate entries, and results in same behavior when removal is involved (the first registered is also the first to be removed). So, let's just remove the check.