### PR TITLE
Plex font family support added

### DIFF
--- a/optex/base/f-plex.opm
+++ b/optex/base/f-plex.opm
@@ -1,0 +1,56 @@
+%% This is part of the OpTeX project, see http://petr.olsak.net/optex
+
+\_famdecl [Plex] \Plex
+   {IBM Plex font family}
+   {\serif \sans \mono
+    \thin \elight \light \regular \text \medium \semibold
+    \cond \nocond}
+   {\rm \bf \it \bi}
+   {}%% No math!
+   {IBMPlexSerif-Regular}
+   {\_def\_fontnamegen {[IBMPlex\_subV-\_currV]:\_fontfeatures}}
+
+\_wlog{\_detokenize{%
+Subfamilies:^^J
+ \serif .... Serif (default)^^J
+ \sans ..... Sans serif^^J
+ \mono ..... Mono^^J%
+Weight modifiers:^^J
+ \thin ........ \rm \it = thin, \bf \bi = light^^J
+ \elight ...... \rm \it = extra light, \bf \bi = regular^^J
+ \light ....... \rm \it = light, \bf \bi = medium^^J
+ \regular ..... \rm \it = regular, \bf \bi = bold (default)^^J
+ \text ........ \rm \it = text, \bf \bi = bold^^J
+ \medium ...... \rm \it = medium, \bf \bi = bold^^J
+ \semibold .... \rm \it = regular, \bf \bi = semibold^^J%
+Modifiers:^^J
+ \cond \nocond .... Condensed (sans serif only)^^J%
+}}
+
+\_moddef \resetmod {\__Plex_nocond \__Plex_serif \__Plex_regularVars}
+
+\_def\__Plex_nocond      {\_fsetV cond={} }
+\_def\__Plex_serif       {\_fsetV sub=Serif }
+\_def\__Plex_regularVars {\_fvars Regular Bold Italic BoldItalic }
+
+\_moddef \serif {\__Plex_serif}
+\_moddef \sans  {\_fsetV sub={Sans\_condV} }
+\_moddef \mono  {\_fsetV sub=Mono }
+
+\_moddef \thin     {\_fvars Thin Light ThinItalic LightItalic }
+\_moddef \elight   {\_fvars ExtraLight Regular ExtraLightItalic Italic }
+\_moddef \light    {\_fvars Light Medium LightItalic MediumItalic }
+\_moddef \regular  {\__Plex_regularVars}
+\_moddef \text     {\_fvars Text Bold TextItalic BoldItalic }
+\_moddef \medium   {\_fvars Medium Bold MediumItalic BoldItalic }
+\_moddef \semibold {\_fvars Regular SemiBold Italic SemiBoldItalic }
+
+\_moddef \cond   {\_fsetV cond=Condensed }
+\_moddef \nocond {\__Plex_nocond}
+
+\_initfontfamily
+
+\_endcode
+
+Official font repository:
+https://github.com/IBM/plex

--- a/optex/base/fams-ini.opm
+++ b/optex/base/fams-ini.opm
@@ -276,10 +276,26 @@
 \_famfrom {Séamas Ó Brógáin}
 \_faminfo [Clara] {Clara, a serif font family} {f-clara}
    { -: {\rm\bf\it\bi} \caps: {\rm} }
-   
+
 \_famfrom {Maxim Iorsh}
 \_faminfo [Culmus] {Hebrew roman, sans and mono fonts from the Culmus project} {f-culmus}
    {\roman,\sans,\mono: {\rm\bf\it\bi}}
+
+\_famfrom {IBM, Mike Abbink, Paul van der Laan, Pieter van Rosmalen}
+\_faminfo [Plex]
+   {IBM Plex font family}
+   {f-plex}
+   { \thin,\elight,\light,-,\text: {\rm\it}
+     \semibold,-: {\bf\bi}
+     \sans\thin,\sans\elight,\sans\light,\sans,\sans\text: {\rm\it}
+     \sans\semibold,\sans: {\bf\bi}
+     \cond\sans\thin,\cond\sans\elight,\cond\sans\light,%
+     \cond\sans,\cond\sans\text: {\rm\it}
+     \cond\sans\semibold,\cond\sans: {\bf\bi}
+     \mono\thin,\mono\elight,\mono\light,\mono,\mono\text: {\rm\it}
+     \mono\semibold,\mono: {\bf\bi}
+   }
+\_famalias[IBM Plex]
 
 \_endcode
 


### PR DESCRIPTION
Plex is a font family created as the corporate typeface of IBM. Fortunately, it was released under an OFL license, so we can use it too. The font is simply available from CTAN.

It's a high-quality font family (serif, sans, mono) with many weight variants ranging from thin to bold. During my work with it, I haven't spotted any problems with these fonts. The only thing missing are small caps.

The font is different, especially the serif and its italics, from the other fonts we already have. This is a clear argument for adding it to OpTeX, but the disadvantage is that there is no visually compatible math font available.

Under the line, we get another high-quality font family for OpTeX.
