### PR TITLE
Using adjusted Garamond-Math in fbb font

### DIFF
--- a/optex/base/f-fbb.opm
+++ b/optex/base/f-fbb.opm
@@ -1,7 +1,7 @@
 %% This is part of the OpTeX project, see http://petr.olsak.net/optex
 
 \_famdecl [fbb] \FBembo {Bembo–like fonts derived from Cardo}
-        {\caps \swash} {\rm \bf \it \bi} {}
+        {\caps \swash} {\rm \bf \it \bi} {adjusted Garamond-Math}
         {[fbb-Regular]}
         {\_def\_fontnamegen {[fbb-\_currV]:script=latn;\_capsV\_swaV\_fontfeatures}}
 
@@ -16,6 +16,8 @@ Modifier:^^J
 \_moddef \swash    {\_fsetV swa=+swsh;+salt; }
 
 \_initfontfamily % new font family must be initialized
+
+\_loadmath 1.06 {[Garamond-Math]} % x-size adjusted Garamond-Math
 
 \_endcode
 


### PR DESCRIPTION
Garamond and fbb share many features, as they belong to the same classification group of fonts. So why don't use the Garamond-Math font as the default math font for fbb.

Exact match is not possible, as every font has its own specifics, but we can get very close here. We must adjust the x-height. I've set the math x-height so that we match as many glyph features as possible with regular, italic, bold and bold italic variants. After that, also the capitals are now matching. So we have a very good overall match...

For this reason, I've described the math font as "adjusted Garamond-Math" in the font file. The reason for this is to tell the user, that regular Garamond-Math won do the job. It must be used with adjusted x-height.

As we set only one value, the x-height, we must make compromises, of course. For example, dots over i or j don't match. We can't match them without introducing other mismatches. The solution has some weaknesses like this, but I think their count is really minimal.

Results were tested magnified on screen and on paper.