### PR TITLE
Parametrized lipsum text source file

### DIFF
--- a/optex/base/others.opm
+++ b/optex/base/others.opm
@@ -110,12 +110,13 @@
 \_def\_lipsumA #1.#2]#3{\_ifx^#2^\_lipsumB #1\_empty-\_empty\_fin \_else \_lipsumdot[#1].\_fi}
 \_def\_lipsumB #1-#2\_empty#3\_fin{%
    \_fornum #1..\_ifx^#2^#1\_else#2\_fi \_do {\_lipsumtext[##1]\_par}}
+\_def\_lipsumfile{lipsum.ltd.tex}
 \_def\_lipsumload{\_beglocalcontrol
    {\_setbox\_nonebox=\_vpack{\_tmpnum=0 % vertical mode during \input lipsum.ltd.tex
       \_def\ProvidesFile##1[##2]{}%
       \_def\SetLipsumLanguage##1{}%
       \_def\NewLipsumPar{\_incr\_tmpnum \_sxdef{_lip:\_the\_tmpnum}}%
-      \_opinput {lipsum.ltd.tex}%
+      \_opinput\_lipsumfile
       \_glet\_lipsumload=\_empty
    }}%
    \_endlocalcontrol}


### PR DESCRIPTION
Minimal change to the lipsum macro to enable loading different source file for the dummy text. Aside from the default `lipsum.ltd.tex` we can use `cicero.ltd.tex` (real Latin), `lipsum-cs.ltd.tex` (Czech), or any other prepared file. All without redefining the \\_lipsumload macro. Only the new \\_lipsumfile macro must be redefined before the first dummy text usage.

No change in the documentation was made, as the change doesn't modify the behavior of the macro. Maybe this new choice should be noted in the documentation, but the whole lipsum docs were written for the default dummy text, and I'm not sure where to change it...
