### PR TITLE
Restructure optex.lua and add to it new PDF utilities

### DIFF
--- a/optex/README
+++ b/optex/README
@@ -82,7 +82,7 @@ History:
        Minor improvements and bug fixing.
 <1.07> May 2022:
        Tikz's \foreach works only in its environment.
-       \lipsum syntax enlarged by dot after paragraph num, example: \lipusm[3.].
+       \lipsum syntax enlarged by dot after paragraph num, example: \lipsum[3.].
        f-baskervald.opm added.
        expandable \isinlist implemented.
        bibstyles \. replaced by \: }due to collision with \oldaccents).


### PR DESCRIPTION
Bring all imports to the top, add new docs, little fixes, and most importantly new utilities for serializng PDF names and strings (to be used in both TeX and Lua).

Just a draft for now, while testing I found some problem with PDF resources, and I am not sure what's the cause yet (recent changes, OpTeX changes, Minim changes, PGF changes, etc.).