### PR TITLE
Don't return true in list callbacks

### DIFF
--- a/optex/base/optex.lua
+++ b/optex/base/optex.lua
@@ -415,17 +415,15 @@ function callback.call_callback(name, ...)
 
     local head = (...)
     local new_head
-    local changed = false
     for _, fn in iter(functions) do
         new_head = fn(head, select(2, ...))
         if new_head == false then
             return false
         elseif new_head ~= true then
             head = new_head
-            changed = true
         end
     end
-    return not changed or head
+    return head
 end
 call_callback = callback.call_callback
 --


### PR DESCRIPTION
I guess whan the code was written
this was compatible with LaTeX's code,
but LaTeX has changed since then:
https://github.com/latex3/latex2e/commit/c038181414defe3b335380cc9521f2c692bd8012 
and handeling the 'true' case is kind of annoying
from a user perspective