### PR TITLE
Fix coloring of outlined fonts

### DIFF
--- a/optex/base/optex.lua
+++ b/optex/base/optex.lua
@@ -39,6 +39,7 @@ local getid = direct.getid
 local getlist = direct.getlist
 local setlist = direct.setlist
 local getleader = direct.getleader
+local getfont = direct.getfont
 local getattribute = direct.get_attribute
 local setattribute = direct.set_attribute
 local insertbefore = direct.insert_before
@@ -53,7 +54,8 @@ local tex_setcount = tex.setcount
 local token_scanint = token.scan_int
 local token_scanlist = token.scan_list
 local token_setmacro = token.set_macro
-
+local font_getfont = font.getfont
+--
 -- \medskip\secc General^^M
 --
 -- Define namespace where \"public" \OpTeX/ functions will be added.
@@ -702,7 +704,9 @@ optex.directpdfliteral = pdfliteral
 -- \TeX/ works with nodes.
 local function is_color_needed(head, n, id, subtype) -- returns fill, stroke color needed
     if id == glyph_id then
-        return true, false
+        local font_id = getfont(n)
+        local mode = font_getfont(font_id).mode
+        return true, mode == 1 or mode == 2
     elseif id == glue_id then
         n = getleader(n)
         if n then


### PR DESCRIPTION
We try to be lazy and only set emit color changing PDF literals when we encounter some TeX node that actually needs the color setting.

For glyph nodes we always returned that fill color is needed and that stroke color is not needed.

This is not correct though, as depending on what `mode` [1] the font is using, it may be filled or stroked. The mode of fill+stroke is used for example by the luaotfload embolden feature [2].

Although it's a bit expensive to check the mode for all the glyphs, it's the simplest way to get correct coloring in presence of outlined fonts implemented by LuaTeX.

[1]: LuaTeX manual, section "The font tables"
[2]: https://github.com/latex3/luaotfload/blob/72561365e3de47c138418af7d11ab335683ff7f0/src/luaotfload-embolden.lua?plain=1#L18