### PR TITLE
f-raleway fontfile corrected

### DIFF
--- a/optex/base/f-raleway.opm
+++ b/optex/base/f-raleway.opm
@@ -4,7 +4,7 @@
         {\thin \elight \light \normal \medium \semibold \bolder \caps}
         {\rm \bf \it \bi} {}
         {[Raleway-Regular]}
-        {\_def\_fontnamegen {[Raleway-\_currV]:script=latn;\_capsV\_fontfeatures}}
+        {\_def\_fontnamegen {[Raleway-\_currV]:\_capsV\_fontfeatures}}
 
 \_wlog{\_detokenize{%
 Modifiers (face weight):^^J
@@ -17,17 +17,17 @@ Modifiers (face weight):^^J
  \bolder .... \rm, \it = Bold, \bf, \bi = Black^^J%
 Capitals, old digits:^^J
  \caps ...... Caps and small caps^^J
- \nocaps .... no Caps and small caps^^J
+ \nocaps .... no Caps and small caps^^J%
 }}
 
-\_moddef \resetmod {\_fsetV caps={} \_fvars Regular SemiBold Regular-Italic SemiBold-Italic }
-\_moddef \thin     {\_fvars Thin Light Thin-Italic Light-Italic }
-\_moddef \elight   {\_fvars ExtraLight Regular ExtraLight-Italic Regular-Italic }
-\_moddef \light    {\_fvars Light Medium Light-Italic Medium-Italic }
-\_moddef \normal   {\_fvars Regular SemiBold Regular-Italic SemiBold-Italic }
-\_moddef \medium   {\_fvars Medium Bold Medium-Italic Bold-Italic }
-\_moddef \semibold {\_fvars SemiBold ExtraBold SemiBold-Italic ExtraBold-Italic }
-\_moddef \bolder   {\_fvars Bold Black Bold-Italic Black-Italic }
+\_moddef \resetmod {\_fsetV caps={} \_fvars Regular SemiBold RegularItalic SemiBoldItalic }
+\_moddef \thin     {\_fvars Thin Light ThinItalic LightItalic }
+\_moddef \elight   {\_fvars ExtraLight Regular ExtraLightItalic RegularItalic }
+\_moddef \light    {\_fvars Light Medium LightItalic MediumItalic }
+\_moddef \normal   {\_fvars Regular SemiBold RegularItalic SemiBoldItalic }
+\_moddef \medium   {\_fvars Medium Bold MediumItalic BoldItalic }
+\_moddef \semibold {\_fvars SemiBold ExtraBold SemiBoldItalic ExtraBoldItalic }
+\_moddef \bolder   {\_fvars Bold Black BoldItalic BlackItalic }
 
 \_moddef \caps     {\_fsetV caps=+smcp;\_ffonum; }
 \_moddef \nocaps   {\_fsetV caps={} }


### PR DESCRIPTION
Problems in the Raleway fontfile corrected:

* Unneeded explicit use `script=latn` removed.
* Wrong filenames for italic variants corrected. 
* Space on last empty line of log message removed.
