### PR TITLE
make \replmacroC long

### DIFF
--- a/optex/base/optex-tricks.opm
+++ b/optex/base/optex-tricks.opm
@@ -213,7 +213,7 @@
    }%
 }
 \_def\.replmacroB #1{\_edef#1{\_csstring#1}}
-\_def\.replmacroC #1#2#3#4{\_useit#2\_def#1#3{#4}}
+\_long\_def\.replmacroC #1#2#3#4{\_useit#2\_def#1#3{#4}}
 
 
 \_trick 0136 \xreplstring ;
@@ -1328,6 +1328,7 @@ end,'global') % we want to keep the meanig after group
 
 \_endcode
 
+2025-12-11 \.replmacroC made long
 2025-03-03 \getnodes introduced, tree structure re-implemented
 2025-02-27 \treedata, \tracingtreedata introduced
 2024-12-13 \algol: \algolem, \aca introduced

--- a/web/optex-tricks.html
+++ b/web/optex-tricks.html
@@ -8087,7 +8087,7 @@ the \macro is re-defined to be equivalent to
    }%
 }
 \def\replmacroB #1{\edef#1{\csstring#1}}
-\def\replmacroC #1#2#3#4{\useit#2\def#1#3{#4}}
+\long\def\replmacroC #1#2#3#4{\useit#2\def#1#3{#4}}
 </pre>
 
 <p CLASS=datum>(0137) -- P. O. 2024-05-06<p>


### PR DESCRIPTION
This is needed in case the body of the macro (argument 4) has a `\par` token.