### PR TITLE
improve trick 170

### DIFF
--- a/optex/base/optex-tricks.opm
+++ b/optex/base/optex-tricks.opm
@@ -1323,11 +1323,55 @@ end,'global') % we want to keep the meanig after group
 
 \_nspublic \ismatch ;
 
+\_trick 0170 \ul \uldefaults ;
+%%%%%%%%%%%%
+
+\_directlua{
+  local funcs = lua.get_functions_table()
+  local luafunction_count = \_csstring#funcs
+  luatexbase.new_luafunction = function(name)
+     luafunction_count = math.max(\_csstring#funcs,luafunction_count) + 1
+     return luafunction_count
+  end
+  luatexbase.callbacktypes.pre_append_to_vlist_filter = "list"
+  require'lua-ul'
+}
+\_let\LuaULSetUnderline\LuaULSetUnderline
+\_let\LuaULNewUnderlineType\LuaULNewUnderlineType
+\_let\LuaULResetUnderline\LuaULResetUnderline
+\_slet{_additcorr}{sw@slant}
+
+\:\_def\uldefaults {% defaults:
+  height=-.65ex,                 % height of rule 
+  depth=.75ex,                   % depth of rule
+  color=,                        % color of the rule (inherited if not declared)
+  transparency=\thetransparency, % transparency of the rule (inherited if not declared)
+  flags=,                        % if flags=over then rule is printed over text
+}
+\_def\.ulcontext{ul:\_kv{flags}:\_kv{transparency}:\.tmpA
+  :\_the\_numexpr\_dimexpr\_kv{height}\_relax\_relax
+  :\_the\_numexpr\_dimexpr\_kv{depth}\_relax\_relax
+}
+\:\_optdef\ul[]{%
+  \_edef\.tmp{\_the\_kvdict}\_kvdict{_optextrick:ul}%
+  \_readkv\uldefaults \_readkv{\_the\_opt}%
+  {\_localcolor\_trykv{color}{}\_xdef\.tmpA{\_the\_colorattr}}%
+  \_trycs{\.ulcontext}{%
+    \_sxdef{\.ulcontext}{\LuaULSetUnderline
+      \LuaULNewUnderlineType\_kv{flags}{\_transparency\_kv{transparency}\_colorattr\.tmpA
+      \_leaders\_vrule height \_kv{height} depth \_kv{depth}\_hskip0pt}}%
+    \_cs{\.ulcontext}}%
+    \_kvdict=\_ea{\.tmp}%
+}
+
+\_addto\_resetattrs{\LuaULResetUnderline*}
+
 %%%%%%%%%%%%
 \_trick end ;
 
 \_endcode
 
+2026-02-14 \ul introduced
 2025-12-11 \.replmacroC made long
 2025-03-03 \getnodes introduced, tree structure re-implemented
 2025-02-27 \treedata, \tracingtreedata introduced

--- a/optex/base/others.opm
+++ b/optex/base/others.opm
@@ -171,7 +171,7 @@
    \onlyifnew \thedimen \rebox \leftfill \rightfill \lrfill \directchar \ereplstring
    \xreplstring \replmacro \tdnum \clipbox \ismatch \isinmacro \mathinexpr \xparshape
    \csvread \csvdecl \dbcreate \inode \enode \execedges \showtree \jsonread \jsoncnv
-   \treedata \tracingtreedata \treenodes ;
+   \treedata \tracingtreedata \treenodes \ul ;
 \_sdef{_item:m}{\_loadtrick{\style m}\_cs{_item:m}}
 
    \_doc

--- a/web/optex-tricks.html
+++ b/web/optex-tricks.html
@@ -560,26 +560,24 @@ hyphenation patterns cannot work properly when such fonts are used.
 
 <p>We can use standard marking by {\it italic}, {\bf bold}, {\bi bold italic}
 or {\em emphasized text}.
-If you want to do something more special, then the following OPmac macros work
-without any change in OpTeX:
+If you want to do something more special, you can:
 
 <ul>
-<li>\ul{text} for underlining text (splittable to more lines)
-    like in the soul LaTeX package, see
+<li>Use {\ul[params] Text} to autoload <a href="#luaul">OpTeX trick 0170</a> and underline, highlight,
+    or overline the text using the <a href="https://ctan.org/pkg/lua-ul">lua-ul package</a>.
+<li>Use <a href="http://petr.olsak.net/opmac-tricks-e.html#soul">OPmac trick 0063</a>,
+    <a href="http://petr.olsak.net/opmac-tricks-e.html#hyphprocess">OPmac trick 0065</a>
+    and <a href="http://petr.olsak.net/opmac-tricks-e.html#coltext">OPmac trick 0085</a>
+    to underline, highlight, or overline the text similarly to the soul LaTeX package.
+    Overlining can be done by the same macro in 
     <a href="http://petr.olsak.net/opmac-tricks-e.html#soul">OPmac trick 0063</a>
-<li>Overlining can be done by the same macro when \uline macro is redefined.
-<li>Leterspacing referred in
+    when \uline macro is redefined.
+    Note that Leterspacing referred in
     <a href="http://petr.olsak.net/opmac-tricks-e.html#soul">OPmac trick 0063</a>
     need not be done by this macro
     because we have more robust letterspacing implemented as font feature,
     se <a href="http://petr.olsak.net/ftp/olsak/optex/optex-doc.pdf#ref:specff">section 2.13.10</a>
     in the OpTeX documentation.
-<li>\hyphenprocess from
-    <a href="http://petr.olsak.net/opmac-tricks-e.html#hyphprocess">OPmac trick 0065</a>
-    can be used to implement hyphenation feature to the \ul macro.
-<li>Background colored (splitabble to more lines) text by
-    <a href="http://petr.olsak.net/opmac-tricks-e.html#coltext">OPmac trick 0085</a>
-    can be printed. Use \coltext\ColorA\ColorB{text}.
 <li>See also the following trick <a href="#attreffects">(OpTeX trick 0064)</a>
     for information about achieving font effects with LuaTeX attributes.
 </ul>
@@ -1014,7 +1012,7 @@ argument to set the rule dimensions (height and depth) we can do
 
 <p> Now for example \ul underlines,
 \ul[height=1.75ex, depth=.75ex, color=\Yellow]
-heighlight the text with a yellow background,
+highlight the text with a yellow background,
 and \ul[height=.55ex, depth=-.45ex, color=\Red, flags=over]
 overline the text with a red line.
 
@@ -5270,6 +5268,11 @@ than single paragraph then you must to re-define \par (or \_par in the new
 OpTeX) in order to do this re-boxing at each paragraph-end between \pstart
 and \pend.
 
+<p>If you need more features for line numbering, such as numbering equation,
+table rows, multicolumns, and have more customizations, you can use the 
+<a href="https://ctan.org/pkg/lualineno">lualineno package</a>, which
+does not redefine the output routine, nor \_par.
+
 <p CLASS=datum>(0069) -- P. O. 2022-02-02<p>
 <hr>
 
@@ -7742,20 +7745,20 @@ Moreover, the \exitstatus counter includes the status value after
 
 <p>The <a href="https://www.ctan.org/pkg/lua-visual-debug">lua-visual-debug package</a>
 allows to show the spaces and box borders in the typesetting output. If you
-have installed it then you can try it. Don't use \input lua-visual-debug.sty.
+have installed it then you can try it. With version 1.0v and above you can do
+\load[lua-visual-debug], otherwise don't use \input lua-visual-debug.sty.
 Use the following commands instead:
 
 <pre>
-\_directlua{ lvd = require("lua-visual-debug")}
-
-\_def \_optexoutput{\_begoutput \_preshipout0\_completepage
-   \_directlua{lvd.show_page_elements(tex.box[0])}
-   \_shipout\_box0 \_endoutput}
+\_directlua{ 
+  local lvd = require("lua-visual-debug")
+  callback.add_to_callback('pre_shipout_filter', lvd.show_page_elements, 'lvd')  
+}
 </pre>
 
-<p>The first line loads the relevant Lua code. Next, we have to re-define
-the \output routine in order to run Lua function lvd.show_page_elements just
-before \shipout.
+<p>The first line loads the relevant Lua code. Next, we add the
+Lua function lvd.show_page_elements to the pre_shipout_filter
+callback.
 
 <p CLASS=datum>(0106) -- P. O. 2023-04-14<p>
 <hr>

--- a/web/optex-tricks.html
+++ b/web/optex-tricks.html
@@ -928,6 +928,10 @@ can sometimes cause surprising side effects.
 
 <h2><a name="luaul"></a>Using the lua-ul package</h2>
 
+<p CLASS="rmarg">
+autoload:<br>\ul
+</p>
+
 <p>The <a href="https://ctan.org/pkg/lua-ul">lua-ul package</a>
 allows to underline, strikethough, and highlight text without affecting
 line breaks, kerning, hypheneation etc. To load it in an OpTeX document
@@ -951,11 +955,11 @@ require'lua-ul'
 and a fix for \_additcorr is required because it may remove a glue or penalty node
 and restore it, but without its attributes, which may affect underlining in some cases.
 
-<p>After loading the lua modue, there are three new macros defined,
+<p>After loading the lua module, there are three new macros defined,
 \LuaULSetUnderline, \LuaULNewUnderlineType and \LuaULResetUnderline.
-\LuaULNewUnderlineType accept a \leader inside curly craces, and expands
+\LuaULNewUnderlineType accept a \leader as an argument, and expands
 to a number that correspond to this leader and an attribute value.
-\LuaULSetUnderline accept this mentioned value and sets and attribute.
+\LuaULSetUnderline accept this mentioned value and sets the attribute.
 You can use these together like so:
 
 <pre>
@@ -966,7 +970,7 @@ You can use these together like so:
 
 <p> Now \ul acts like a font switch command, and you can do {\ul underlined}.
 Note that this leader is frozen at creation time, so e.g. {\Red\ul underlined}
-will not produce red line. If you want the undeline to respect colors you can
+will not produce red line. If you want the underline to respect colors you can
 create new underline types dynamically. For example:
 
 <pre>
@@ -980,9 +984,50 @@ create new underline types dynamically. For example:
 }
 </pre>
 
-<p>You can also use \directlua{tex.print(tex.sp("1ex"))} to respect font size etc.
+<p> For a more general coammand, which also respect transparency, and accept an optional
+argument to set the rule dimensions (height and depth) we can do
 
-<p>\LuaULResetUnderline disables all lua-ul's attributes, you can use it in \_resetattrs.
+<pre>
+\def\uldefaults {% defaults:
+  height=-.65ex,                 % height of rule 
+  depth=.75ex,                   % depth of rule
+  color=,                        % color of the rule (inherited if not declared)
+  transparency=\thetransparency, % transparency of the rule (inherited if not declared)
+  flags=,                        % if flags=over then rule is printed over text
+}
+\def\ulcontext{ul:\kv{flags}:\kv{transparency}:\tmpA
+  :\the\numexpr\dimexpr\kv{height}\relax\relax
+  :\the\numexpr\dimexpr\kv{depth}\relax\relax
+}
+\optdef\ul[]{%
+  \edef\tmp{\the\kvdict}\kvdict{ul}%
+  \readkv\uldefaults \readkv{\the\opt}%
+  {\localcolor\trykv{color}{}\xdef\tmpA{\the\_colorattr}}%
+  \trycs{\ulcontext}{%
+    \sxdef{\ulcontext}{\LuaULSetUnderline
+      \LuaULNewUnderlineType\kv{flags}{\transparency\kv{transparency}\_colorattr\tmpA
+      \leaders\vrule height \kv{height} depth \kv{depth}\hskip0pt}}%
+    \cs{\ulcontext}}%
+    \kvdict=\ea{\tmp}%
+}
+</pre>
+
+<p> Now for example \ul underlines,
+\ul[height=1.75ex, depth=.75ex, color=\Yellow]
+heighlight the text with a yellow background,
+and \ul[height=.55ex, depth=-.45ex, color=\Red, flags=over]
+overline the text with a red line.
+
+<p> Note that unlike colors, or fonts, we can have several 
+active underlines in the same time.
+To have double unserlines for example
+you can simply do {\ul \ul[height=-.45ex, depth=.55ex] Text}
+
+<p>The \LuaULResetUnderline dsables the last activated underline,
+if there is no activated one it will error, but \ul respect grouping so
+usually you won't need to use it. If there is a * 
+after it it disables all underlines (and do not error),
+you can do \addto \_resetattrs {\LuaULResetUnderline*}.
 <p CLASS=datum>(0170) -- Udi Fogiel, 2025-11-25<p>
 <hr>
 


### PR DESCRIPTION
This commit shows how to define more general
\ul command using lua-ul, which can be used
to underline, heighlight and overline.

In addition it adds it to optex-tricks.opm
so it could be loaded on the fly.

An example:
```tex
\transparency=1
{\ul Text}
{\ul[height=1.75ex,depth=.75ex,color=\Yellow,] Text}
{\ul[height=.55ex, depth=-.45ex,color=\Red,flags=over] Text}
```
<img width="1440" height="328" alt="image" src="https://github.com/user-attachments/assets/77e924d6-94da-4834-a0c2-25f854be1b1d" />

Note that control the color of the rule one can also do
```tex
{\Red\ul{\Black Text}}
```

So the color and transparency keys are not really needed, but I though it is more convenient.
Do you think they are redundant?

The `\transparency=1` is in the example because of a bug in `\transparency` with values<1.