### PR TITLE
remove spurious space around \roundframe

### DIFF
--- a/optex/base/optex-tricks.opm
+++ b/optex/base/optex-tricks.opm
@@ -598,7 +598,7 @@ end,'global') % we want to keep the meanig after group
          \_noindent\_strut\_kv{title-color}\_kv{title-font}#1\.parstrut\_kern\_kv{title-below}}
       \_kv{midrule-color}\_hrule height\_kv{midrule-width}%
       \.bgbox{\_kv{text-bgcolor}}{\_kern\_kv{text-above}%
-         \_noindent\_strut\_kv{text-color}\_kv{text-font}#2\.parstrut\_kern\_kv{text-below}}}
+         \_noindent\_strut\_kv{text-color}\_kv{text-font}#2\.parstrut\_kern\_kv{text-below}}}%
    \_setbox1=\_vbox to\_dimexpr\_ht0-2\_roundness{}\_wd1=\_dimexpr\_wd0-2\_roundness\_relax
    \_hbox{\_unless\_ifdim\_kv{shadow-width}=0pt \.roundframeshadow \_fi
       \_clipinoval .5\_wd0 .5\_ht0 \_wd0 \_ht0 {\_box0}}%

--- a/web/optex-tricks.html
+++ b/web/optex-tricks.html
@@ -2253,7 +2253,7 @@ with rounded corners. For example
          \noindent\strut\kv{title-color}\kv{title-font}#1\parstrut\kern\kv{title-below}}
       \kv{midrule-color}\hrule height\kv{midrule-width}%
       \bgbox{\kv{text-bgcolor}}{\kern\kv{text-above}%
-         \noindent\strut\kv{text-color}\kv{text-font}#2\parstrut\kern\kv{text-below}}}
+         \noindent\strut\kv{text-color}\kv{text-font}#2\parstrut\kern\kv{text-below}}}%
    \setbox1=\vbox to\dimexpr\ht0-2\roundness{}\wd1=\dimexpr\wd0-2\roundness\relax
    \hbox{\unless\ifdim\kv{shadow-width}=0pt \roundframeshadow \fi
       \clipinoval .5\wd0 .5\ht0 \wd0 \ht0 {\box0}}%


### PR DESCRIPTION
example
```tex
\frame{\roundframe {Title here}
            {Text dgd adhkd had dsglj dagjadg fsj csgsd
             gs sgls fsglfs gfsl fglf gfs rtyr rire wrurey.}}
\bye
```