### PR TITLE
set \_completepage direction to \_pagedirection

### DIFF
--- a/optex/base/output.opm
+++ b/optex/base/output.opm
@@ -264,6 +264,7 @@ The output routine \^`\_optexoutput` is similar as in plain \TeX. It does:
 \enditems
 
 \_endinput
+
 2026-03-26 set \_vbox direction to \_pagedirection in \_completepage
 2025-05-04 \_pdfrunninglinkoff, \_pdfrunninglinkon moved, used only if non-empty \headline
 2024-02-29 \_pdfrunninglinkoff, \_pdfrunninglinkon used

--- a/optex/base/output.opm
+++ b/optex/base/output.opm
@@ -74,7 +74,7 @@
    and no transparency.
    \_cod -----------------------------
 
-\_def\_completepage{\_vbox{%
+\_def\_completepage{\_vbox bdir\_pagedirection{%
      \_resetattrs
      \_istoksempty \_pgbackground
         \_iffalse \_backgroundbox{\_the\_pgbackground}\_nointerlineskip \_fi
@@ -264,7 +264,7 @@ The output routine \^`\_optexoutput` is similar as in plain \TeX. It does:
 \enditems
 
 \_endinput
-
+2026-03-26 set \_vbox direction to \_pagedirection in \_completepage
 2025-05-04 \_pdfrunninglinkoff, \_pdfrunninglinkon moved, used only if non-empty \headline
 2024-02-29 \_pdfrunninglinkoff, \_pdfrunninglinkon used
 2022-04-28 \_optexshipout introduced


### PR DESCRIPTION
The `\_vbox` created in the output routine in \_completepage inherit the direction of `\_bodydirection`, which can differ from \_pagedirection if someone changes it for a secondary language, and there is a page break during that time.