### PR TITLE
fix set_node_color bug

### DIFF
--- a/optex/base/optex.lua
+++ b/optex/base/optex.lua
@@ -13,6 +13,7 @@
 -- \enditems
 
 local fmt = string.format
+local string_upper = string.upper
 
 local node_id = node.id
 local node_subtype = node.subtype
@@ -825,15 +826,16 @@ end, "_colors")
 --
 -- The hook has to be registered {\em after} `luaotfload` is loaded.
 local color_count = registernumber("_colorcnt")
+local optex_catcode = registernumber("_optexcatcodes")
 local function set_node_color(n, color) -- "1 0 0 rg" or "0 g", etc.
     local attr = tonumber(token_getmacro("_color::"..color))
     if not attr then
         attr = tex_getcount(color_count)
-        tex_setcount(color_count, attr + 1)
+        tex_setcount("global", color_count, attr + 1)
         local strattr = tostring(attr)
-        token_setmacro("_color::"..color, strattr, "global")
-        token_setmacro("_color:"..strattr, color, "global")
-        token_setmacro("_color-s:"..strattr, string.upper(color), "global")
+        token_setmacro(optex_catcode, "_color::"..color, strattr, "global")
+        token_setmacro(optex_catcode, "_color:"..strattr, color, "global")
+        token_setmacro(optex_catcode, "_color-s:"..strattr, string_upper(color), "global")
     end
     setattribute(todirect(n), color_attribute, attr)
 end

--- a/web/optex-tricks.html
+++ b/web/optex-tricks.html
@@ -1551,7 +1551,7 @@ autoload:<br>\algolnum
 </p>
 
 <p>We suppose that you are using \algol macro from OpTeX trick
-<a href="algol">0078</a>
+<a href="#algol">0078</a>
 and you want to active line numbering. If you write
 
 <pre>
@@ -1609,7 +1609,7 @@ autoload:<br>\setaca
 
 <p>We cannot simply arrange for the comments (beginning with //) to be aligned
 (one above second) when printing algorithms (pseudocodes, see OpTeX ticks
-<a href="algol">0078</a>). The reason is that we don't exactly know the width of the
+<a href="#algol">0078</a>). The reason is that we don't exactly know the width of the
 code before the comments, so putting appropriate number of spaces before the
 comments cannot help.
 
@@ -4317,7 +4317,7 @@ in the database.
 
 <p>If there is more equal Data item in the column used for searching then
 the line with the first one is returned by \dbwhere. More options shows
-<a href="dbprint">OpTeX trick 0150, Tip 4</a>.
+<a href="#dbprint">OpTeX trick 0150, Tip 4</a>.
 
 <p>If a named database is crated by \csvread basename{filename.csv} then
 following commands can be used:


### PR DESCRIPTION
* \_colorcnt should be incremented globally (as done from the TeX side with \_incr)

* Normal category codes should be used to set the color macros (to avoid problems with spaces)